### PR TITLE
Add model description fallback

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -138,7 +138,7 @@ class RipeCommonsMainPlugin extends RipeCommonsPlugin {
                 brand: this.ripe.brand,
                 model: this.ripe.model,
                 variant: this.ripe.options.variant,
-                description: this.ripe.options.description,
+                description: this.ripe.options.description || config.description,
                 product_id: this.ripe.options.product_id,
                 dku: this.ripe.options.dku,
                 parts: this.ripe.parts || {}


### PR DESCRIPTION
Sometimes models don't have explicit descriptions. When that happens, fallback to whatever RIPE SDK provides (currently the tech name) to avoid the description not being switched when the model changes.