### PR TITLE
Hack for fixing overflow in iOS 13.1

### DIFF
--- a/vue/components/pickers/pickers.vue
+++ b/vue/components/pickers/pickers.vue
@@ -261,6 +261,7 @@
     transform: scale(1, 1);
     transition: transform 0.125s ease-in-out, border-width 0.125s ease-in-out;
     width: 58px;
+    z-index: 1;
 }
 
 .pickers.multiple-materials .colors-container .color > .swatch {


### PR DESCRIPTION
With the new iOS 13.1 there seems to have been some kind of breaking change that makes the `overflow: hidden` in the swatches not work when there is scrolling in its container.

Somehow it seems that [setting the z-index fixes the issue](https://gist.github.com/adamcbrewer/5859738#gistcomment-2008691).

Before:
<img width="501" alt="Screenshot 2019-09-30 at 12 46 39" src="https://user-images.githubusercontent.com/3048875/65876161-8ba9f080-e380-11e9-8d0c-fb6b590bbf61.png">

After:
<img width="514" alt="Screenshot 2019-09-30 at 12 46 42" src="https://user-images.githubusercontent.com/3048875/65876164-8e0c4a80-e380-11e9-9364-76c379f23708.png">

Another option would be to [add](https://gist.github.com/ayamflow/b602ab436ac9f05660d9c15190f4fd7b) `-webkit-mask-image: -webkit-radial-gradient(white, black);`.

I could only reproduce this issue on iOS `13.1` using a real device or the MacOS simulator. Even with the same Safari and webkit versions (13.0.1 or 605.1.15) it wasn't reproducible in desktop.