### PR TITLE
Protect against invalid initial groups

### DIFF
--- a/vue/components/personalization.vue
+++ b/vue/components/personalization.vue
@@ -285,6 +285,14 @@ export const personalization = {
             this.state = state;
             this.tabMessage = tabMessage;
 
+            // delete invalid initials extra groups, which are the ones that
+            // do not define both initials and engraving
+            Object.entries(state.initialsExtra).forEach(([group, value]) => {
+                if (!(value.engraving && value.initials)) {
+                    delete state.initialsExtra[group];
+                }
+            });
+
             // in case there's no visibility of the personalization then applies the
             // changes and then runs the update of the button text
             !this.visible && this.apply();


### PR DESCRIPTION
The absence of this fix was making it impossible to have personalization when one of the groups had no initials (e.g. Sergio Rossi with letters just on the left shoe), given that it violated RIPE SDK preconditions and threw an exception.