### PR TITLE
RS-225: Get rid of ghost space below pickers

### DIFF
--- a/vue/components/pickers/pickers.vue
+++ b/vue/components/pickers/pickers.vue
@@ -328,37 +328,39 @@
 }
 
 .pickers .message-undo-container {
-    height: auto;
-    max-height: 50px;
-    position: absolute;
-    overflow-y: visible;
-    left:50%;
     bottom: 25%;
+    height: auto;
+    left: 50%;
+    max-height: 50px;
+    overflow-y: visible;
+    position: absolute;
     transition: max-height 0.5s ease-in-out;
-    
 }
 
 .pickers .message-undo-container.invisible {
-    overflow: hidden;
-    max-height: 0;
     animation: 1.2s delay-overflow;
+    max-height: 0;
+    overflow: hidden;
 }
 
 @keyframes delay-overflow {
-  from { overflow: visible; }
+
+    from {
+        overflow: visible;
+    }
 }
 
 .pickers .message-undo {
-    left: -50%;
-    position: relative;
     background-color: #ececec;
     border-radius: 5px;
     display: block;
     font-size: 11px;
+    left: -50%;
     line-height: 14px;
     margin: 0px auto 0px auto;
     max-width: 580px;
     padding: 10px 20px 10px 30px;
+    position: relative;
     text-align: left;
     transform: translateY(100%);
     transition: transform 0.5s ease-in-out;

--- a/vue/components/pickers/pickers.vue
+++ b/vue/components/pickers/pickers.vue
@@ -9,7 +9,7 @@
         ref="pickersContainer"
     >
         <div class="message-undo-container" v-bind:class="{ invisible: !allowUndo }">
-            <div class="message-undo">
+            <div class="message-undo" v-bind:class="{ visible: allowUndo }">
                 <a class="button button-undo" v-on:click="undo()">{{
                     "ripe_commons.pickers.undo" | locale
                 }}</a>
@@ -330,15 +330,27 @@
 .pickers .message-undo-container {
     height: auto;
     max-height: 50px;
-    overflow: hidden;
-    transition: max-height 0.5s ease-in;
+    position: absolute;
+    overflow-y: visible;
+    left:50%;
+    bottom: 25%;
+    transition: max-height 0.5s ease-in-out;
+    
 }
 
 .pickers .message-undo-container.invisible {
+    overflow: hidden;
     max-height: 0;
+    animation: 1.2s delay-overflow;
+}
+
+@keyframes delay-overflow {
+  from { overflow: visible; }
 }
 
 .pickers .message-undo {
+    left: -50%;
+    position: relative;
     background-color: #ececec;
     border-radius: 5px;
     display: block;
@@ -348,8 +360,12 @@
     max-width: 580px;
     padding: 10px 20px 10px 30px;
     text-align: left;
-    transform: translateY(0);
+    transform: translateY(100%);
     transition: transform 0.5s ease-in-out;
+}
+
+.pickers .message-undo.visible {
+    transform: translateY(0px);
 }
 
 .pickers .message-undo .button.button-undo {

--- a/vue/components/pickers/pickers.vue
+++ b/vue/components/pickers/pickers.vue
@@ -328,7 +328,7 @@
 }
 
 .pickers .message-undo-container {
-    bottom: 27%;
+    bottom: 25%;
     height: auto;
     left: 50%;
     max-height: 50px;

--- a/vue/components/pickers/pickers.vue
+++ b/vue/components/pickers/pickers.vue
@@ -328,18 +328,21 @@
 }
 
 .pickers .message-undo-container {
-    bottom: 25%;
+    bottom: 27%;
     height: auto;
     left: 50%;
     max-height: 50px;
+    opacity: 1;
     overflow-y: visible;
     position: absolute;
-    transition: max-height 0.5s ease-in-out;
+    transition: max-height 0.5s ease-in-out, opacity 0.2s;
+    width: 100%;
 }
 
 .pickers .message-undo-container.invisible {
-    animation: 1.2s delay-overflow;
+    animation: 0.3s delay-overflow;
     max-height: 0;
+    opacity: 0;
     overflow: hidden;
 }
 

--- a/vue/components/pickers/pickers.vue
+++ b/vue/components/pickers/pickers.vue
@@ -1,15 +1,18 @@
 <template>
     <div
         class="pickers"
-        v-bind:class="{ 'multiple-materials': multipleMaterials, loading: loading, visible: allowUndo }"
+        v-bind:class="{
+            'multiple-materials': multipleMaterials,
+            loading: loading,
+            visible: allowUndo
+        }"
         ref="pickersContainer"
     >
         <div class="message-undo-container" v-bind:class="{ invisible: !allowUndo }">
             <div class="message-undo">
-                <a
-                    class="button button-undo"
-                    v-on:click="undo()"
-                >{{ "ripe_commons.pickers.undo" | locale }}</a>
+                <a class="button button-undo" v-on:click="undo()">{{
+                    "ripe_commons.pickers.undo" | locale
+                }}</a>
                 <span>
                     {{ "ripe_commons.pickers.limited" | locale }}
                     {{ "ripe_commons.pickers.back" | locale }}
@@ -36,10 +39,9 @@
                     <div class="swatch" v-if="selectedColor(part) && selectedColor(part).color">
                         <img v-bind:src="partSwatch(part)" />
                     </div>
-                    <p
-                        class="no-part"
-                        v-else-if="isOptional(part)"
-                    >{{ localeModel(part, "no_" + part) }}</p>
+                    <p class="no-part" v-else-if="isOptional(part)">
+                        {{ localeModel(part, "no_" + part) }}
+                    </p>
                 </li>
                 <slot />
             </ul>
@@ -95,7 +97,12 @@
                 v-on:click="slideLeftColors"
             />
             <transition name="fade">
-                <ul class="colors-container" v-show="activeMaterial !== null" ref="colorsPicker" v-bind:class="{ visible: !allowUndo }">
+                <ul
+                    class="colors-container"
+                    v-bind:class="{ visible: !allowUndo }"
+                    v-show="activeMaterial !== null"
+                    ref="colorsPicker"
+                >
                     <transition-group name="list" ref="colorsList">
                         <li
                             class="color button button-color"
@@ -141,8 +148,8 @@
 }
 
 .pickers {
-    padding: 0px 0px 16px 0px;
     margin-bottom: -20px;
+    padding: 0px 0px 16px 0px;
 }
 
 .pickers.visible {
@@ -321,9 +328,9 @@
 }
 
 .pickers .message-undo-container {
-    overflow: hidden;
-    max-height: 50px;
     height: auto;
+    max-height: 50px;
+    overflow: hidden;
     transition: max-height 0.5s ease-in;
 }
 

--- a/vue/components/pickers/pickers.vue
+++ b/vue/components/pickers/pickers.vue
@@ -1,9 +1,21 @@
 <template>
     <div
         class="pickers"
-        v-bind:class="{ 'multiple-materials': multipleMaterials, loading: loading }"
+        v-bind:class="{ 'multiple-materials': multipleMaterials, loading: loading, visible: allowUndo }"
         ref="pickersContainer"
     >
+        <div class="message-undo-container" v-bind:class="{ invisible: !allowUndo }">
+            <div class="message-undo">
+                <a
+                    class="button button-undo"
+                    v-on:click="undo()"
+                >{{ "ripe_commons.pickers.undo" | locale }}</a>
+                <span>
+                    {{ "ripe_commons.pickers.limited" | locale }}
+                    {{ "ripe_commons.pickers.back" | locale }}
+                </span>
+            </div>
+        </div>
         <div class="background" />
         <div class="parts-wrapper">
             <div
@@ -24,9 +36,10 @@
                     <div class="swatch" v-if="selectedColor(part) && selectedColor(part).color">
                         <img v-bind:src="partSwatch(part)" />
                     </div>
-                    <p class="no-part" v-else-if="isOptional(part)">
-                        {{ localeModel(part, "no_" + part) }}
-                    </p>
+                    <p
+                        class="no-part"
+                        v-else-if="isOptional(part)"
+                    >{{ localeModel(part, "no_" + part) }}</p>
                 </li>
                 <slot />
             </ul>
@@ -82,7 +95,7 @@
                 v-on:click="slideLeftColors"
             />
             <transition name="fade">
-                <ul class="colors-container" v-show="activeMaterial !== null" ref="colorsPicker">
+                <ul class="colors-container" v-show="activeMaterial !== null" ref="colorsPicker" v-bind:class="{ visible: !allowUndo }">
                     <transition-group name="list" ref="colorsList">
                         <li
                             class="color button button-color"
@@ -119,23 +132,22 @@
                 v-on:click="slideRightColors"
             />
         </div>
-        <div class="message-undo-container">
-            <div class="message-undo" v-bind:class="{ visible: allowUndo }">
-                <a class="button button-undo" v-on:click="undo()">
-                    {{ "ripe_commons.pickers.undo" | locale }}
-                </a>
-                <span>
-                    {{ "ripe_commons.pickers.limited" | locale }}
-                    {{ "ripe_commons.pickers.back" | locale }}
-                </span>
-            </div>
-        </div>
     </div>
 </template>
 
 <style scoped>
 .pickers > .parts-wrapper {
     position: relative;
+}
+
+.pickers {
+    padding: 0px 0px 16px 0px;
+    margin-bottom: -20px;
+}
+
+.pickers.visible {
+    padding: 0;
+    transform: padding 0.5s ease-in-out;
 }
 
 .pickers .parts-container > .part {
@@ -310,6 +322,13 @@
 
 .pickers .message-undo-container {
     overflow: hidden;
+    max-height: 50px;
+    height: auto;
+    transition: max-height 0.5s ease-in;
+}
+
+.pickers .message-undo-container.invisible {
+    max-height: 0;
 }
 
 .pickers .message-undo {
@@ -322,12 +341,8 @@
     max-width: 580px;
     padding: 10px 20px 10px 30px;
     text-align: left;
-    transform: translateY(-100%);
+    transform: translateY(0);
     transition: transform 0.5s ease-in-out;
-}
-
-.pickers .message-undo.visible {
-    transform: translateY(0px);
 }
 
 .pickers .message-undo .button.button-undo {


### PR DESCRIPTION
[RS-225: Get rid of ghost space below pickers](https://platforme.atlassian.net/browse/RS-225)
Message Undo not appearing above pickers, not changing pickers height when it appears.

![Screen-Recording-2019-10-24-at-12 43 10](https://user-images.githubusercontent.com/25725586/67482699-16b69780-f65c-11e9-8dc6-669f9f8e3fb6.gif)
