### PR TITLE
Improve loader component hide timing

### DIFF
--- a/vue/components/configurator.vue
+++ b/vue/components/configurator.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="configurator-container">
-        <loader class="loader" v-if="!modelLoaded && !modelError" />
+        <loader class="loader" v-if="loading && !modelError" />
         <div class="configurator" v-bind:class="{ loading: loading }">
             <div class="config" ref="configurator" />
             <div class="error" v-if="modelError">


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-commons-pluginus/issues/XXX |
| Decisions | Improve loader component hide timing to be closer to the rendering of the first image. |
| Animated GIF | Below |

### Before
![RXVQSTQVe3](https://user-images.githubusercontent.com/24736423/68932605-e067c600-078a-11ea-8841-43518b64e3d1.gif)


### After
![BW3ngBbM7n](https://user-images.githubusercontent.com/24736423/68932518-b6ae9f00-078a-11ea-99bd-2cc7ceb65b98.gif)