### PR TITLE
Enable personalization by default

### DIFF
--- a/vue/components/personalization.vue
+++ b/vue/components/personalization.vue
@@ -208,10 +208,10 @@ export const personalization = {
             // sets the form for the current component, sets it as enable and hidden
             // by default (initial state)
             this.form = form;
-            this.enabled = false;
             this.hidden = false;
 
             this.initialOptions = Object.assign({}, options);
+            this.enablePersonalization();
         });
 
         this.$bus.bind("initials_extra", initialsExtra => {

--- a/vue/components/personalization.vue
+++ b/vue/components/personalization.vue
@@ -210,6 +210,9 @@ export const personalization = {
             this.form = form;
             this.hidden = false;
 
+            // copies the provided options from the post config as the initial options
+            // for the initials and then triggers the enable operation on the
+            // personalization, effectively enabling personalization on the configurator
             this.initialOptions = Object.assign({}, options);
             this.enablePersonalization();
         });


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | - |
| Decisions | Personalization was disabled by default, forcing plugin implementations to explicitly trigger a `enable_personalization` event. This was just being done for Sergio Rossi, meaning that all other implementations would never have the personalization button enabled.  This was a [breaking change](https://github.com/ripe-tech/ripe-commons-pluginus/commit/0c2feb84fd2834cae7d423fd384dcb43b88d4747) motivated by not wanting the button to appear enabled when it's still loading, but with the current implementation, both scenarios seem to be accounted for.  |
| Animated GIF |   |
