### PR TITLE
Fix pickers border

### DIFF
--- a/vue/components/pickers/pickers.vue
+++ b/vue/components/pickers/pickers.vue
@@ -268,7 +268,6 @@
 
 .pickers .colors-container .color:hover > .swatch,
 .pickers .colors-container .color.active > .swatch {
-    border-width: 0px;
     transform: scale(1.13, 1.13);
 }
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Border disappears when selected or on mouse hover. Related to https://github.com/ripe-tech/ripe-white/pull/159 |
| Decisions | - |
| Animated GIF | - |

### Before
<img width="299" alt="imagem" src="https://user-images.githubusercontent.com/24736423/73563948-77711f80-4456-11ea-9c5c-226d36a58a58.png">

### After
<img width="299" alt="imagem" src="https://user-images.githubusercontent.com/24736423/73563922-67594000-4456-11ea-9803-c902ddcc08b0.png">
