### PR TITLE
Use the correct bus in Storybook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,13 +1,12 @@
 import Vue from "vue";
 import { configure } from "@storybook/vue";
 
-import { install as RipeCommonsPluginusVue } from "../vue";
+import { install as RipeCommonsPluginusVue, busPlugin } from "../vue";
 
 import "./styles.css";
 
+Vue.use(busPlugin);
 Vue.use(RipeCommonsPluginusVue);
-
-Vue.prototype.$bus = new Vue();
 
 const req = require.context("../vue", true, /\.stories\.js$/);
 function loadStories() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | All pluginus apps use a pluginus bus, not a Vue bus, therefore the storybook must reflect that. |
