### PR TITLE
Rename variant in logic mixin

### DIFF
--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -17,7 +17,7 @@ const logicMixin = {
         productId() {
             return this.$store.state.product_id;
         },
-        variant() {
+        modelVariant() {
             return this.$store.state.variant;
         },
         flag() {


### PR DESCRIPTION
Renamed `variant` since we usually use that as a prop for UI components (e.g. `dense`, etc). I've confirmed that this wasn't being used in neither in Retail nor White.