### PR TITLE
#169 Mobile layout with dots instead of thumbnails

### DIFF
--- a/vue/components/atoms/dot-thumbnail/dot-thumbnail.vue
+++ b/vue/components/atoms/dot-thumbnail/dot-thumbnail.vue
@@ -1,18 +1,14 @@
 <template>
     <div class="dot-container" v-on:click="showFrame">
-        <dot
-            v-bind:color="'dark'"
-            v-bind:subtle="!active"
-            v-bind:size="10"
-        />
+        <dot v-bind:color="'dark'" v-bind:subtle="!active" v-bind:size="10" />
     </div>
 </template>
 
 <style scoped>
 .dot-container {
+    cursor: pointer;
     display: inline-block;
     padding: 15px 15px 15px 15px;
-    cursor: pointer;
 }
 </style>
 

--- a/vue/components/atoms/dot-thumbnail/dot-thumbnail.vue
+++ b/vue/components/atoms/dot-thumbnail/dot-thumbnail.vue
@@ -1,0 +1,41 @@
+<template>
+    <div class="dot-container" v-on:click="showFrame">
+        <dot
+            v-bind:color="'dark'"
+            v-bind:subtle="!active"
+            v-bind:size="10"
+        />
+    </div>
+</template>
+
+<style scoped>
+.dot-container {
+    display: inline-block;
+    padding: 15px 15px 15px 15px;
+    cursor: pointer;
+}
+</style>
+
+<script>
+export const DotThumbnail = {
+    name: "dot-thumbnail",
+    props: {
+        frame: {
+            type: String,
+            required: true
+        }
+    },
+    computed: {
+        active() {
+            return this.frame === this.$store.state.currentFrame;
+        }
+    },
+    methods: {
+        showFrame() {
+            this.$bus.trigger("show_frame", this.frame);
+        }
+    }
+};
+
+export default DotThumbnail;
+</script>

--- a/vue/components/atoms/dot-thumbnail/index.js
+++ b/vue/components/atoms/dot-thumbnail/index.js
@@ -1,0 +1,1 @@
+export { DotThumbnail } from "./dot-thumbnail.vue";

--- a/vue/components/atoms/index.js
+++ b/vue/components/atoms/index.js
@@ -1,6 +1,7 @@
 import { Alert } from "./alert/alert.vue";
 import { Button } from "./button/button.vue";
 import { ButtonPlatforme } from "./button-platforme/button-platforme.vue";
+import { DotThumbnail } from "./dot-thumbnail/dot-thumbnail.vue";
 import { Icon } from "./icon/icon.vue";
 import { Loader } from "./loader/loader.vue";
 import { Thumbnail } from "./thumbnail/thumbnail.vue";
@@ -9,11 +10,12 @@ const install = Vue => {
     Vue.component("alert", Alert);
     Vue.component("button-ripe", Button);
     Vue.component("button-platforme", ButtonPlatforme);
+    Vue.component("dot-thumbnail", DotThumbnail);
     Vue.component("icon", Icon);
     Vue.component("loader", Loader);
     Vue.component("thumbnail", Thumbnail);
 };
 
-export { Alert, Button, ButtonPlatforme, Icon, Loader, Thumbnail };
+export { Alert, Button, ButtonPlatforme, DotThumbnail, Icon, Loader, Thumbnail };
 
 export default install;

--- a/vue/components/molecules/dots/dots.vue
+++ b/vue/components/molecules/dots/dots.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="dots thumbnails" ref="thumbnailsContainer">
+    <div class="thumbnails" ref="thumbnailsContainer">
         <dot-thumbnail
             v-bind:frame="`${thumbnail.face}-${thumbnail.frame}`"
             v-bind:name="thumbnail.name"

--- a/vue/components/molecules/dots/dots.vue
+++ b/vue/components/molecules/dots/dots.vue
@@ -2,7 +2,6 @@
     <div class="thumbnails" ref="thumbnailsContainer">
         <dot-thumbnail
             v-bind:frame="`${thumbnail.face}-${thumbnail.frame}`"
-            v-bind:name="thumbnail.name"
             v-for="thumbnail in thumbnails"
             v-bind:key="thumbnailKey(thumbnail)"
         />

--- a/vue/components/molecules/dots/dots.vue
+++ b/vue/components/molecules/dots/dots.vue
@@ -1,0 +1,28 @@
+<template>
+    <div class="dots thumbnails" ref="thumbnailsContainer">
+        <dot-thumbnail
+            v-bind:frame="`${thumbnail.face}-${thumbnail.frame}`"
+            v-bind:name="thumbnail.name"
+            v-for="thumbnail in thumbnails"
+            v-bind:key="thumbnailKey(thumbnail)"
+        />
+    </div>
+</template>
+
+<script>
+export const Dots = {
+    name: "dots",
+    computed: {
+        thumbnails() {
+            return this.$store.getters.thumbnails;
+        }
+    },
+    methods: {
+        thumbnailKey(thumbnail) {
+            return `${thumbnail.frame}:${thumbnail.name}:${thumbnail.face}`;
+        }
+    }
+};
+
+export default Dots;
+</script>

--- a/vue/components/molecules/dots/index.js
+++ b/vue/components/molecules/dots/index.js
@@ -1,0 +1,1 @@
+export { Dots } from "./dots.vue";

--- a/vue/components/molecules/index.js
+++ b/vue/components/molecules/index.js
@@ -1,5 +1,6 @@
 import { Ask } from "./ask/ask.vue";
 import { ComponentPlugin } from "./component-plugin/component-plugin.vue";
+import { Dots } from "./dots/dots.vue";
 import { Keyboard } from "./keyboard/keyboard.vue";
 import { Modal } from "./modal/modal.vue";
 import { RestrictionsAlert } from "./restrictions-alert/restrictions-alert.vue";
@@ -10,6 +11,7 @@ import { Thumbnails } from "./thumbnails/thumbnails.vue";
 const install = Vue => {
     Vue.component("ask", Ask);
     Vue.component("component-plugin", ComponentPlugin);
+    Vue.component("dots", Dots);
     Vue.component("keyboard", Keyboard);
     Vue.component("modal", Modal);
     Vue.component("restrictions-alert", RestrictionsAlert);
@@ -18,6 +20,6 @@ const install = Vue => {
     Vue.component("thumbnails", Thumbnails);
 };
 
-export { Ask, ComponentPlugin, Keyboard, Modal, RestrictionsAlert, Tab, Tabs, Thumbnails };
+export { Ask, ComponentPlugin, Dots, Keyboard, Modal, RestrictionsAlert, Tab, Tabs, Thumbnails };
 
 export default install;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/169 |
| Dependencies | - |
| Decisions | Add more costumization to dot component. Add dot thumbnail component.  |
| Animated GIF | - |