### PR TITLE
Exposet set model options

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -110,7 +110,14 @@ class RipeCommonsMainPlugin extends RipeCommonsPlugin {
         return [RipeCommonsCapability.new("start"), RipeCommonsCapability.new("ripe-provider")];
     }
 
-    async setModelOptions({ brand = null, model = null, query = null, dku = null, productId = null, setModel = true } = {}) {
+    async setModelOptions({
+        brand = null,
+        model = null,
+        query = null,
+        dku = null,
+        productId = null,
+        setModel = true
+    } = {}) {
         let modelConfig = {};
         if (query) {
             modelConfig = this.ripe._queryToSpec(query);
@@ -122,7 +129,8 @@ class RipeCommonsMainPlugin extends RipeCommonsPlugin {
 
         this.options = Object.assign({ brand: brand, model: model }, modelConfig);
 
-        if (setModel) await this.setModel(this.options).catch(async err => await this._handleCritical(err));
+        if (setModel)
+            { await this.setModel(this.options).catch(async err => await this._handleCritical(err)); }
     }
 
     async setModel(options = null) {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Expose a higher-level operation for changing the current model. While the existing `setModel` works, it would force clients to re-implement the resolving of the DKU, product ID, etc. This is provided as a global mixin rather than an event bus to allow `await`ing for it so that we can have loading or similar. |
