### PR TITLE
#313: Fix init with parts and DKU

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -89,8 +89,11 @@ class RipeCommonsMainPlugin extends RipeCommonsPlugin {
         if (this.options.brand && this.options.model) {
             Object.assign(config, {
                 brand: this.options.brand,
-                model: this.options.model
+                model: this.options.model,
+                parts: this.options.parts || {}
             });
+        } else if (this.options.dku) {
+            Object.assign(config, { dku: this.options.dku });
         }
         // otherwise if there's a valid product id defined then we should resolve
         // it and update the current options with its resolved values

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -496,7 +496,7 @@ export const Pickers = {
             this.multipleMaterials = false;
         },
         activePart(part, oldPart) {
-            if (!part) {
+            if (!part || !this.materialOptions) {
                 return;
             }
             const current = this.parts[this.activePart];
@@ -763,6 +763,7 @@ export const Pickers = {
             return colors;
         },
         materialColors(material) {
+            if (!this.materialOptions) return;
             const colors = [];
             let index = 0;
             const materialColors = this.materialOptions[material] || [];

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -464,7 +464,7 @@ export const Pickers = {
         },
         colorOptions() {
             if (!this.activeMaterial) {
-                return null;
+                return {};
             } else if (this.multipleMaterials === false || this.colorToggle === true) {
                 return this.materialColors(this.activeMaterial);
             } else {

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -460,7 +460,7 @@ export const Pickers = {
             return choices;
         },
         materialOptions() {
-            return this.activePart ? this.filteredOptions[this.activePart] : null;
+            return this.activePart ? this.filteredOptions[this.activePart] || {} : {};
         },
         colorOptions() {
             if (!this.activeMaterial) {
@@ -496,7 +496,7 @@ export const Pickers = {
             this.multipleMaterials = false;
         },
         activePart(part, oldPart) {
-            if (!part || !this.materialOptions) {
+            if (!part) {
                 return;
             }
             const current = this.parts[this.activePart];
@@ -763,7 +763,6 @@ export const Pickers = {
             return colors;
         },
         materialColors(material) {
-            if (!this.materialOptions) return;
             const colors = [];
             let index = 0;
             const materialColors = this.materialOptions[material] || [];


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Fixes https://github.com/ripe-tech/ripe-white/issues/313 |
| Decisions | We were completely ignoring how White sets the parts (`options.parts`) or the DKU (`options.dku`). Besides, `pickers` had to be adapted because for some reason when entering with the DKU the `post_config` event is triggered before the `choices`, even though they're being triggered in the correct order by the RIPE SDK's `update`, which means that it's not guaranteed that the available options (choices) are ready when a part becomes active (when a config changes)  |
