### PR TITLE
Sync version to the URL

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -198,6 +198,7 @@ class RipeCommonsMainPlugin extends RipeCommonsPlugin {
                 brand: this.ripe.brand,
                 model: this.ripe.model,
                 variant: this.ripe.options.variant,
+                version: this.ripe.options.version,
                 description: this.ripe.options.description,
                 product_id: this.ripe.options.product_id,
                 dku: this.ripe.options.dku,

--- a/js/util/url-changer.js
+++ b/js/util/url-changer.js
@@ -36,6 +36,9 @@ class UrlChangerPlugin extends RipeCommonsPlugin {
         if (model.variant) query.set("variant", model.variant);
         else query.delete("variant");
 
+        if (model.version) query.set("version", model.version);
+        else query.delete("version");
+
         if (model.flag) query.set("flag", model.flag);
         else query.delete("flag");
 

--- a/vue/store.js
+++ b/vue/store.js
@@ -9,7 +9,7 @@ export const store = {
         dku: "",
         product_id: "",
         variant: "",
-        version: null,
+        version: "",
         description: "",
         flag: "",
         format: "",

--- a/vue/store.js
+++ b/vue/store.js
@@ -9,6 +9,7 @@ export const store = {
         dku: "",
         product_id: "",
         variant: "",
+        version: null,
         description: "",
         flag: "",
         format: "",
@@ -39,6 +40,7 @@ export const store = {
             state.dku = model.dku;
             state.product_id = model.product_id;
             state.variant = model.variant;
+            state.version = model.version;
             state.description = model.description;
             state.parts = model.parts;
         },
@@ -120,6 +122,7 @@ export const store = {
             brand: state.brand,
             model: state.model,
             variant: state.variant,
+            version: state.version,
             flag: state.flag,
             format: state.format,
             gender: state.gender,
@@ -138,6 +141,7 @@ export const store = {
                 scale: state.size.scale,
                 size: state.size.size,
                 variant: state.variant,
+                version: state.version,
                 parts: state.parts,
                 country: state.country,
                 currency: state.currency,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Now that versions are a first-class citizen, particularly in RIPE White with the builds explorer, it should also be included in the URL. It was already possible to enter with a specific version in the URL, so it even makes more sense. |
