### PR TITLE
Fix money format for 0

### DIFF
--- a/vue/filters/money.js
+++ b/vue/filters/money.js
@@ -84,7 +84,7 @@ Money._formatCurrency = function(money, currency, useSymbol) {
 };
 
 Money.formatMoney = function(value, currency, places, separator, thousands, useSymbol) {
-    if (!value) {
+    if (value === null || value === undefined) {
         return "";
     }
     useSymbol = useSymbol === undefined ? true : useSymbol;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | A call for `money(0, "USD")` is perfectly valid but would product `` rather than `$ 0.00` due to `0` being coerced to `false`. This fixes it. |
