### PR TITLE
#234: Fix regression by re-adding slot

### DIFF
--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -68,6 +68,7 @@
                         </slot>
                     </li>
                 </slot>
+                <slot />
             </ul>
             <div
                 class="button-scroll button-scroll-right button-scroll-parts button-scroll-parts-right"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Fixes https://github.com/ripe-tech/ripe-retail/issues/234 |
| Decisions | Reverts the regression created in https://github.com/ripe-tech/ripe-commons-pluginus/commit/997b3aa42c735b7d9e6106fe407f3779bd14f4c3#diff-38c90b47b74305883cdb8712366f3538 by re-adding the deleted default slot, which RIPE Retail was using for injecting the personalization button.  |
