### PR TITLE
Fixes reading version and description on post_config

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -242,8 +242,8 @@ class RipeCommonsMainPlugin extends RipeCommonsPlugin {
                 brand: this.ripe.brand,
                 model: this.ripe.model,
                 variant: this.ripe.options.variant,
-                version: this.ripe.options.version,
-                description: this.ripe.options.description,
+                version: config.version,
+                description: config.description,
                 product_id: this.ripe.options.product_id,
                 dku: this.ripe.options.dku,
                 parts: this.ripe.parts || {}


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Reading the `version` from options results in a poor update, because we would get `null` instead of the latest version. The store should reflect what's actually being represented in the SDK, not its options. Another way to go about this would be the SDK to update its own version. |
