### PR TITLE
Fix modal padding in firefox

### DIFF
--- a/vue/components/molecules/modal/modal.vue
+++ b/vue/components/molecules/modal/modal.vue
@@ -80,9 +80,9 @@
     border-radius: 4px 4px 4px 4px;
     box-shadow: 0px 0px 12px #2d2d2d;
     display: inline-block;
-    max-height: 85%;
+    max-height: 95%;
     overflow-y: auto;
-    padding: 40px 40px 0px 40px;
+    padding: 0px 40px 0px 40px;
     transition: opacity 0.25s ease-out, transform 0.2s ease-out;
     z-index: 1;
 }
@@ -90,9 +90,9 @@
 body.tablet .modal > .modal-container,
 body.mobile .modal > .modal-container {
     box-sizing: border-box;
-    max-height: 95%;
+    max-height: 98%;
     max-width: 100%;
-    padding: 20px 10px 0px 10px;
+    padding: 0px 10px 0px 10px;
 }
 
 .modal.fade-enter > .modal-container {
@@ -114,6 +114,15 @@ body.mobile .modal > .modal-container {
     transform: scale(0.97);
 }
 
+.modal > .modal-container > :nth-child(2) {
+    padding-top: 40px;
+}
+
+body.tablet .modal > .modal-container > :nth-child(2),
+body.mobile .modal > .modal-container > :nth-child(2) {
+    padding-top: 20px;
+}
+
 .modal > .modal-container > :last-child {
     padding-bottom: 40px;
 }
@@ -125,14 +134,12 @@ body.mobile .modal > .modal-container > :last-child {
 
 .modal > .modal-container > .modal-header {
     margin-left: -40px;
-    margin-top: -40px;
     position: fixed;
 }
 
 body.tablet .modal > .modal-container > .modal-header,
 body.mobile .modal > .modal-container > .modal-header {
     margin-left: -10px;
-    margin-top: -35px;
 }
 
 .modal > .modal-container > .modal-header > .button.button-close {

--- a/vue/components/molecules/modal/modal.vue
+++ b/vue/components/molecules/modal/modal.vue
@@ -80,7 +80,7 @@
     border-radius: 4px 4px 4px 4px;
     box-shadow: 0px 0px 12px #2d2d2d;
     display: inline-block;
-    max-height: 80%;
+    max-height: 85%;
     overflow-y: auto;
     padding: 40px 40px 0px 40px;
     transition: opacity 0.25s ease-out, transform 0.2s ease-out;
@@ -90,9 +90,9 @@
 body.tablet .modal > .modal-container,
 body.mobile .modal > .modal-container {
     box-sizing: border-box;
-    max-height: 90%;
+    max-height: 95%;
     max-width: 100%;
-    padding: 20px 10px 20px 10px;
+    padding: 20px 10px 0px 10px;
 }
 
 .modal.fade-enter > .modal-container {
@@ -112,6 +112,15 @@ body.mobile .modal > .modal-container {
 .modal.fade-leave-to > .modal-container {
     opacity: 0;
     transform: scale(0.97);
+}
+
+.modal > .modal-container > :last-child {
+    padding-bottom: 40px;
+}
+
+body.tablet .modal > .modal-container > :last-child,
+body.mobile .modal > .modal-container > :last-child {
+    padding-bottom: 20px;
 }
 
 .modal > .modal-container > .modal-header {
@@ -193,10 +202,6 @@ body.mobile .modal .modal-content ::v-deep > div > div > .title {
 .modal .modal-content ::v-deep .buttons-container > .button.button-cancel:hover,
 .modal .modal-content ::v-deep .buttons-container > .button.button-cancel:active {
     color: #000000;
-}
-
-.modal .modal-footer {
-    padding: 0px 0px 40px 0px;
 }
 </style>
 

--- a/vue/components/molecules/modal/modal.vue
+++ b/vue/components/molecules/modal/modal.vue
@@ -82,7 +82,7 @@
     display: inline-block;
     max-height: 80%;
     overflow-y: auto;
-    padding: 40px 40px 40px 40px;
+    padding: 40px 40px 0px 40px;
     transition: opacity 0.25s ease-out, transform 0.2s ease-out;
     z-index: 1;
 }
@@ -193,6 +193,10 @@ body.mobile .modal .modal-content ::v-deep > div > div > .title {
 .modal .modal-content ::v-deep .buttons-container > .button.button-cancel:hover,
 .modal .modal-content ::v-deep .buttons-container > .button.button-cancel:active {
     color: #000000;
+}
+
+.modal .modal-footer {
+    padding: 0px 0px 40px 0px;
 }
 </style>
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | No issue created. But the issue is that on firefox the padding-bottom isn't being respected when a `overflow-y: auto` css is present in the code |
| Decisions | Passed the bottom padding to the latest child of `modal-footer` instead of is container `modal-container`. |
| Animated GIF |  Bug:</br><img width="1024" alt="Screenshot 2020-05-08 at 10 43 13" src="https://user-images.githubusercontent.com/13239857/81393750-c7781600-9118-11ea-9b51-9d7063a98cca.png"></br>Fix:<br><img width="1024" alt="Screenshot 2020-05-08 at 10 42 39" src="https://user-images.githubusercontent.com/13239857/81393956-16be4680-9119-11ea-91be-aa08563ed3dc.png"> |
| Dependencies | - |
