### PR TITLE
Add config version to store

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -254,6 +254,7 @@ class RipeCommonsMainPlugin extends RipeCommonsPlugin {
             this.store.commit("hasCustomization", this.ripe.hasCustomization());
             this.store.commit("hasPersonalization", this.ripe.hasPersonalization());
             this.store.commit("hasSize", this.ripe.hasSize());
+            this.store.commit("versionConfig", config.version);
         });
 
         // changes some internal structure whenever there's an update

--- a/vue/store.js
+++ b/vue/store.js
@@ -30,7 +30,8 @@ export const store = {
         error: null,
         hasCustomization: false,
         hasPersonalization: false,
-        hasSize: false
+        hasSize: false,
+        versionConfig: null
     },
     mutations: {
         ripe_url(state, url) {
@@ -120,6 +121,9 @@ export const store = {
         },
         hasSize(state, hasSize) {
             state.hasSize = hasSize;
+        },
+        versionConfig(state, versionConfig) {
+            state.versionConfig = versionConfig;
         }
     },
     getters: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Adds the current config's version to the store. This is not the version I've defined in the SDK but the version that is indeed being used, which can be useful for some tech plugins to display information. |
