### PR TITLE
#448: Fix entering with product ID or DKU

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -230,7 +230,7 @@ class RipeCommonsMainPlugin extends RipeCommonsPlugin {
     async setRipeOptions(options, force = false) {
         const ripeState = this._getRipeState();
         const changed = Object.entries(ripeState).filter(
-            ([key, value]) => options[key] !== undefined && options[key] !== value
+            ([key, value]) => options[key] && options[key] !== value
         );
         if (changed.length === 0 && !force) return;
         await this.ripe.config(this.ripe.brand, this.ripe.model, { ...options });


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/448 |
| Decisions | Options that are not defined shouldn't cause a new SDK configuration request. The source of options, the Vuex store, has all kinds of ways to say something is undefined (null, empty string, undefined, ...) so the comparison can't be so strict. |
