### PR TITLE
#349: Generic personalization plugin

### DIFF
--- a/bundles/config.en_us.json
+++ b/bundles/config.en_us.json
@@ -14,6 +14,7 @@
 
     "ripe_commons.personalization.personalization": "Personalisation",
     "ripe_commons.personalization.add_initials": "Add initials",
+    "ripe_commons.personalization.group": "Group",
 
     "ripe_commons.size.size": "Size",
     "ripe_commons.size.select_size": "Select Size",

--- a/bundles/config.en_us.json
+++ b/bundles/config.en_us.json
@@ -15,6 +15,11 @@
     "ripe_commons.personalization.personalization": "Personalisation",
     "ripe_commons.personalization.add_initials": "Add initials",
     "ripe_commons.personalization.group": "Group",
+    "ripe_commons.personalization.initials": "Initials",
+    "ripe_commons.personalization.select.style": "Select the style",
+    "ripe_commons.personalization.select.font": "Select the font",
+    "ripe_commons.personalization.select.position": "Select the position",
+    "ripe_commons.personalization.select.color": "Select the color",
 
     "ripe_commons.size.size": "Size",
     "ripe_commons.size.select_size": "Select Size",

--- a/js/index.js
+++ b/js/index.js
@@ -8,7 +8,7 @@ import {
     ModelLocaleResolverPlugin
 } from "./locale";
 
-import { BaseSizePlugin } from "./ui";
+import { BasePersonalizationPlugin, BaseSizePlugin } from "./ui";
 
 export * from "./abstract";
 export * from "./base";
@@ -22,6 +22,7 @@ const registerPlugins = owner => {
     LocalePlugin.register(owner);
     ModelLocaleLoaderPlugin.register(owner);
     ModelLocaleResolverPlugin.register(owner);
+    BasePersonalizationPlugin.register(owner);
     BaseSizePlugin.register(owner);
     DevicePlugin.register(owner);
     UrlChangerPlugin.register(owner);

--- a/js/ui/base-personalization/base-personalization.js
+++ b/js/ui/base-personalization/base-personalization.js
@@ -1,7 +1,7 @@
 import { RipeCommonsPlugin, RipeCommonsCapability } from "../../abstract";
 import { BasePersonalization } from "./base-personalization.vue";
 
-class BasePersonalizationPlugin extends RipeCommonsPlugin {
+export class BasePersonalizationPlugin extends RipeCommonsPlugin {
     getCapabilities() {
         return [
             RipeCommonsCapability.new("component"),
@@ -20,5 +20,3 @@ class BasePersonalizationPlugin extends RipeCommonsPlugin {
 }
 
 BasePersonalizationPlugin.register();
-
-export { BasePersonalizationPlugin };

--- a/js/ui/base-personalization/base-personalization.js
+++ b/js/ui/base-personalization/base-personalization.js
@@ -1,0 +1,24 @@
+import { RipeCommonsPlugin, RipeCommonsCapability } from "../../abstract";
+import { BasePersonalization } from "./base-personalization.vue";
+
+class BasePersonalizationPlugin extends RipeCommonsPlugin {
+    getCapabilities() {
+        return [
+            RipeCommonsCapability.new("component"),
+            RipeCommonsCapability.new("component-personalization"),
+            RipeCommonsCapability.new("personalization")
+        ];
+    }
+
+    async getComponent() {
+        return BasePersonalization;
+    }
+
+    async getPersonalizationComponent() {
+        return BasePersonalization;
+    }
+}
+
+BasePersonalizationPlugin.register();
+
+export { BasePersonalizationPlugin };

--- a/js/ui/base-personalization/base-personalization.vue
+++ b/js/ui/base-personalization/base-personalization.vue
@@ -1,0 +1,9 @@
+<script>
+import { components } from "../../../vue";
+
+export const BasePersonalization = {
+    extends: components.personalizationForm.Reference
+};
+
+export default BasePersonalization;
+</script>

--- a/js/ui/base-personalization/index.js
+++ b/js/ui/base-personalization/index.js
@@ -1,2 +1,1 @@
-export * from "./base-size";
 export * from "./base-personalization";

--- a/js/ui/index.js
+++ b/js/ui/index.js
@@ -1,2 +1,2 @@
-export * from "./base-size";
 export * from "./base-personalization";
+export * from "./base-size";

--- a/vue/components/forms/personalization-form/index.js
+++ b/vue/components/forms/personalization-form/index.js
@@ -1,9 +1,11 @@
 import { Interface } from "./interface";
 import { InitialsImages } from "./initials-images.vue";
 import { InitialsInputs } from "./initials-inputs.vue";
+import { Reference } from "./reference.vue";
 
 export const formInterface = Interface;
 export const initialsImages = InitialsImages;
 export const initialsInputs = InitialsInputs;
+export const reference = Reference;
 
-export { Interface, InitialsImages, InitialsInputs };
+export { Interface, InitialsImages, InitialsInputs, Reference };

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -53,6 +53,21 @@ export const InitialsImages = {
             initialsImages: []
         };
     },
+    watch: {
+        async groups(value) {
+            await Promise.all(this.initialsImages.map(async image => this.$ripe.unbindImage(image)));
+
+            const initialsImages = this.$refs.initialsImages || [];
+            for (const initialsImage of initialsImages) {
+                const image = this.$ripe.bindImage(initialsImage, {
+                    showInitials: true,
+                    initialsGroup: initialsImage.dataset.group,
+                    initialsBuilder: this.initialsBuilder
+                });
+                this.initialsImages.push(image);
+            }
+        }
+    },
     mounted: function() {
         const initialsImages = this.$refs.initialsImages || [];
         for (const initialsImage of initialsImages) {

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -55,7 +55,11 @@ export const InitialsImages = {
     },
     watch: {
         async groups(value) {
-            await Promise.all(this.initialsImages.map(async image => this.$ripe.unbindImage(image)));
+            // unbind all images and clean all binds, so that new ones can be bound
+            await Promise.all(
+                this.initialsImages.map(async image => this.$ripe.unbindImage(image))
+            );
+            this.initialsImages = [];
 
             const initialsImages = this.$refs.initialsImages || [];
             for (const initialsImage of initialsImages) {

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -55,12 +55,25 @@ export const InitialsImages = {
     },
     watch: {
         async groups(value) {
-            // unbind all images and clean all binds, so that new ones can be bound
-            await Promise.all(
-                this.initialsImages.map(async image => this.$ripe.unbindImage(image))
-            );
+            await this.unbindImages();
+            this.bindImages();
+        }
+    },
+    mounted: function() {
+        this.bindImages();
+    },
+    destroyed: async function() {
+        await this.unbindImages();
+    },
+    methods: {
+        groupKey(group) {
+            return [this.brand, this.model, group].join(":");
+        },
+        imageSelected(group) {
+            this.$emit("image-selected", group);
+        },
+        bindImages() {
             this.initialsImages = [];
-
             const initialsImages = this.$refs.initialsImages || [];
             for (const initialsImage of initialsImages) {
                 const image = this.$ripe.bindImage(initialsImage, {
@@ -70,28 +83,11 @@ export const InitialsImages = {
                 });
                 this.initialsImages.push(image);
             }
-        }
-    },
-    mounted: function() {
-        const initialsImages = this.$refs.initialsImages || [];
-        for (const initialsImage of initialsImages) {
-            const image = this.$ripe.bindImage(initialsImage, {
-                showInitials: true,
-                initialsGroup: initialsImage.dataset.group,
-                initialsBuilder: this.initialsBuilder
-            });
-            this.initialsImages.push(image);
-        }
-    },
-    destroyed: async function() {
-        await Promise.all(this.initialsImages.map(async image => this.$ripe.unbindImage(image)));
-    },
-    methods: {
-        groupKey(group) {
-            return [this.brand, this.model, group].join(":");
         },
-        imageSelected(group) {
-            this.$emit("image-selected", group);
+        async unbindImages() {
+            await Promise.all(
+                this.initialsImages.map(async image => this.$ripe.unbindImage(image))
+            );
         }
     }
 };

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -18,7 +18,7 @@
                     v-bind:key="type"
                 >
                     <select-ripe
-                        v-bind:placeholder="'Select the position'"
+                        v-bind:placeholder="`Select the ${type}`"
                         v-bind:options="options"
                         v-bind:value="propertiesData[group][type]"
                         v-on:update:value="value => onValueUpdate(value, group, type)"
@@ -72,7 +72,7 @@ body.mobile .generic-personalization > .initials-images ::v-deep .initials-image
 
 .generic-personalization > .form > .form-group > .subtitle {
     font-size: 14px;
-    margin-top: 10px;
+    margin: 16px 0px 20px 0px;
     text-transform: capitalize;
 }
 

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -127,19 +127,13 @@ export const Reference = {
             return this.$store.state.model;
         },
         fonts() {
-            return this.$store.state.config.initials.properties
-                .filter(property => property.type === "font")
-                .map(property => ({ value: property.name, label: property.name }));
+            return this.getPropertyOptions("font");
         },
         positions() {
-            return this.$store.state.config.initials.properties
-                .filter(property => property.type === "position")
-                .map(property => ({ value: property.name, label: property.name }));
+            return this.getPropertyOptions("position");
         },
         styles() {
-            return this.$store.state.config.initials.properties
-                .filter(property => property.type === "style")
-                .map(property => ({ value: property.name, label: property.name }));
+            return this.getPropertyOptions("style");
         },
         state() {
             // font engraving is used to force the refresh of state after setState
@@ -237,6 +231,11 @@ export const Reference = {
             }
 
             return initials.length ? initials.join(" ") + " " + engravings.join(" ") : "";
+        },
+        getPropertyOptions(propertyType) {
+            return this.$store.state.config.initials.properties
+                .filter(property => property.type === propertyType)
+                .map(property => ({ value: property.name, label: property.name }));
         },
         async getGroups() {
             try {

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -92,9 +92,9 @@ body.mobile .generic-personalization > .initials-images ::v-deep .initials-image
 }
 
 .generic-personalization > .form > .form-group > .subtitle {
+    font-size: 14px;
     margin-top: 10px;
     text-transform: capitalize;
-    font-size: 14px;
 }
 
 .generic-personalization > .form > .form-group > .form-input {
@@ -204,12 +204,13 @@ export const Reference = {
                 // when entering with a null engraving,
                 // replace string null value so that it
                 // does not appear in tab message
-                const engraving = this.fontData[name] && this.fontData[name] !== "null"
-                    ? this.locale(
-                          "properties.font." + this.fontData[name].split(":")[0],
-                          this.readable(this.capitalize(this.fontData[name]))
-                      )
-                    : "";
+                const engraving =
+                    this.fontData[name] && this.fontData[name] !== "null"
+                        ? this.locale(
+                              "properties.font." + this.fontData[name].split(":")[0],
+                              this.readable(this.capitalize(this.fontData[name]))
+                          )
+                        : "";
                 engravings.push(engraving);
             }
 

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -200,6 +200,7 @@ export const Reference = {
                     "";
                 this.$set(this.initialsText, name, initials);
                 this.$set(this.fontData, name, engraving);
+                this.$set(this.styleData, name, engraving);
                 this.fontEngraving = this.fontData[name];
             }
         },

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -258,6 +258,7 @@ export const Reference = {
 
             if (this.fontData[group]) {
                 this.groups.length > 1 && profiles.push(this.fontData[group] + ":" + group);
+                profiles.push(this.fontData[group]);
             }
 
             if (this.positionData[group]) {
@@ -281,7 +282,11 @@ export const Reference = {
 
             const position = this.positionData[group] || "";
             return []
-                .concat(alias[`step::personalization:${position}`], alias["step::personalization"])
+                .concat(
+                    alias[`step::personalization:${position}`],
+                    alias[`step::personalization:${position}:${group}`],
+                    alias["step::personalization"]
+                )
                 .filter(v => v !== undefined);
         },
         __getInitials() {

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -1,0 +1,257 @@
+<template>
+    <div class="generic-personalization">
+        <initials-images
+            v-bind:brand="brand"
+            v-bind:model="model"
+            v-bind:groups="groups"
+            v-bind:active-group="activeGroup"
+            v-bind:initials-builder="__initialsBuilder"
+            ref="initialsImages"
+        />
+        <div class="form">
+            <div class="form-group" v-for="group in groups" v-bind:key="group">
+                <p class="subtitle">
+                    {{ "ripe_commons.personalization.group" | locale }} {{ group }}
+                </p>
+                <form-input
+                    v-bind:header="'Position'"
+                    v-bind:header-size="'large'"
+                    v-if="positions.length !== 0"
+                >
+                    <select-ripe
+                        v-bind:placeholder="'Select the position'"
+                        v-bind:options="positions"
+                        v-bind:value.sync="positionData[group]"
+                    />
+                </form-input>
+                <form-input
+                    v-bind:header="'Style'"
+                    v-bind:header-size="'large'"
+                    v-if="styles.length !== 0"
+                >
+                    <select-ripe
+                        v-bind:placeholder="'Select the style'"
+                        v-bind:options="styles"
+                        v-bind:value.sync="styleData[group]"
+                    />
+                </form-input>
+                <form-input
+                    v-bind:header="'Font'"
+                    v-bind:header-size="'large'"
+                    v-if="fonts.length !== 0"
+                >
+                    <select-ripe
+                        v-bind:placeholder="'Select the font'"
+                        v-bind:options="fonts"
+                        v-bind:value.sync="fontData[group]"
+                    />
+                </form-input>
+                <form-input v-bind:header="'Initials*'" v-bind:header-size="'large'">
+                    <input-ripe
+                        v-bind:placeholder="'Add Initials'"
+                        v-bind:value.sync="initialsData[group]"
+                    />
+                </form-input>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.generic-personalization {
+    max-width: 100%;
+    min-width: 600px;
+}
+
+.generic-personalization > .initials-images ::v-deep .initials-image {
+    border-radius: 50%;
+    max-height: 300px;
+    margin-right: 30px;
+}
+
+.generic-personalization > .initials-images ::v-deep .initials-image:last-of-type {
+    margin-right: 0px;
+}
+
+.generic-personalization > .form {
+    display: flex;
+    justify-content: center;
+}
+
+.generic-personalization > .form > .form-group {
+    width: 100%;
+    margin-right: 30px;
+}
+
+.generic-personalization > .form > .form-group:last-of-type {
+    margin-right: 0px;
+}
+
+.generic-personalization > .form > .form-group > .subtitle {
+    text-transform: capitalize;
+    margin-top: 10px;
+}
+
+.generic-personalization > .form > .form-group > .form-input {
+    text-align: left;
+    margin-bottom: 20px;
+}
+</style>
+
+<script>
+import formInterface from "./interface.js";
+
+export const Reference = {
+    name: "reference-personalization",
+    mixins: [formInterface],
+    data: function() {
+        return {
+            positionData: {},
+            styleData: {},
+            fontData: {},
+            initialsData: {},
+            activeGroup: "",
+            groups: [],
+            initials: {},
+            fontEngraving: ""
+        };
+    },
+    computed: {
+        brand() {
+            return this.$store.state.brand;
+        },
+        model() {
+            return this.$store.state.model;
+        },
+        fonts() {
+            return this.$store.state.config.initials.properties
+                .filter(property => property.type === "font")
+                .map(property => ({ value: property.name, label: property.name }));
+        },
+        positions() {
+            return this.$store.state.config.initials.properties
+                .filter(property => property.type === "position")
+                .map(property => ({ value: property.name, label: property.name }));
+        },
+        styles() {
+            return this.$store.state.config.initials.properties
+                .filter(property => property.type === "style")
+                .map(property => ({ value: property.name, label: property.name }));
+        },
+        profile() {
+            const profileUsed = this.$store.state.config.initials.profile;
+            return this.$store.state.config.initials.$profiles[profileUsed];
+        },
+        state() {
+            return this.groups.length > 1
+                ? {
+                      initialsExtra: this.__getInitials()
+                  }
+                : {
+                      initials: this.initialsData[this.groups[0]]
+                  };
+        }
+    },
+    watch: {
+        state: {
+            handler: function() {
+                this.$emit("changed", this);
+            },
+            deep: true
+        }
+    },
+    mounted: async function() {
+        await this.getGroups();
+    },
+    methods: {
+        async show() {
+            await this.getGroups();
+        },
+        reset() {
+            return this.setState({
+                initials: {}
+            });
+        },
+        setState(state) {
+            const initials = {};
+            const initialsExtra = state.initialsExtra || {};
+            for (const name of this.groups) {
+                const group = initialsExtra[name] || {};
+                const engraving = group.engraving || this.fontEngraving;
+                initials[name] = {
+                    initials: group.initials || "",
+                    engraving: engraving
+                };
+                this.style = engraving;
+            }
+            this.initials = initials;
+        },
+        getState() {
+            return this.state;
+        },
+        getTabMessage() {},
+        async getGroups() {
+            this.groups = await this.$ripe.getLogicP({
+                brand: this.$store.state.brand,
+                model: this.$store.state.model,
+                method: "groups"
+            });
+            if (this.groups && this.groups.length > 0) this.activeGroup = this.groups[0];
+        },
+        __initialsBuilder(initials, engraving, element) {
+            if (this.groups.length > 1) {
+                const group = element.getAttribute("data-group");
+                const viewport = "large";
+                const profiles = [];
+
+                if (this.fontData[group]) {
+                    profiles.push(this.font + ":" + group, this.font + ":" + viewport);
+                }
+
+                profiles.push(group + ":" + viewport);
+
+                if (this.fontData[group]) {
+                    profiles.push(this.font);
+                }
+
+                profiles.push(group, viewport);
+
+                return {
+                    initials: initials,
+                    profile: profiles
+                };
+            }
+
+            const profiles = [];
+            profiles.push(engraving);
+
+            return {
+                initials: initials,
+                profile: profiles
+            };
+        },
+        __getInitials() {
+            const _initials = {};
+            for (const name in this.initialsData) {
+                const group = {
+                    initials: this.initialsData[name],
+                    engraving: this.__buildEngraving(name)
+                };
+                _initials[name] = group;
+            }
+            return _initials;
+        },
+        __buildEngraving(group) {
+            if (this.styleData[group]) {
+                this.fontEngraving = `${this.styleData[group]}:style`;
+            }
+            if (this.fontData[group]) {
+                this.fontEngraving = `${this.fontData[group]}:font`;
+            }
+            return this.fontEngraving;
+        }
+    }
+};
+
+export default Reference;
+</script>

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -68,6 +68,11 @@
     max-height: 300px;
 }
 
+body.tablet .generic-personalization > .initials-images ::v-deep .initials-image,
+body.mobile .generic-personalization > .initials-images ::v-deep .initials-image {
+    width: auto;
+}
+
 .generic-personalization > .initials-images ::v-deep .initials-image:last-of-type {
     margin-right: 0px;
 }
@@ -89,6 +94,7 @@
 .generic-personalization > .form > .form-group > .subtitle {
     margin-top: 10px;
     text-transform: capitalize;
+    font-size: 14px;
 }
 
 .generic-personalization > .form > .form-group > .form-input {

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -12,7 +12,7 @@
                     {{ "ripe_commons.personalization.group" | locale }} {{ group }}
                 </p>
                 <form-input
-                    v-bind:header="locale(`properties.${type}`, readable(capitalize(type)))"
+                    v-bind:header="(`properties.${type}`, readable(capitalize(type))) | locale"
                     v-bind:header-size="'large'"
                     v-for="[type, options] in Object.entries(properties)"
                     v-bind:key="type"

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -173,7 +173,6 @@ export const Reference = {
                 // gives a default group if builds does not support logic
                 this.groups = ["main"];
             }
-            this.reset();
 
             // when loading a model with a personalization already set (URL)
             // the setState is called first, so the state of personalization

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -12,21 +12,24 @@
                     {{ "ripe_commons.personalization.group" | locale }} {{ group }}
                 </p>
                 <form-input
-                    v-bind:header="capitalize(type)"
+                    v-bind:header="locale(`properties.${type}`, readable(capitalize(type)))"
                     v-bind:header-size="'large'"
                     v-for="[type, options] in Object.entries(properties)"
                     v-bind:key="type"
                 >
                     <select-ripe
-                        v-bind:placeholder="`Select the ${type}`"
+                        v-bind:placeholder="`ripe_commons.personalization.select.${type}` | locale"
                         v-bind:options="options"
                         v-bind:value="propertiesData[group][type]"
                         v-on:update:value="value => onValueUpdate(value, group, type)"
                     />
                 </form-input>
-                <form-input v-bind:header="'Initials*'" v-bind:header-size="'large'">
+                <form-input
+                    v-bind:header="'ripe_commons.personalization.initials' | locale"
+                    v-bind:header-size="'large'"
+                >
                     <input-ripe
-                        v-bind:placeholder="'Add Initials'"
+                        v-bind:placeholder="'ripe_commons.personalization.add_initials' | locale"
                         v-bind:value.sync="initialsText[group]"
                     />
                 </form-input>
@@ -109,7 +112,10 @@ export const Reference = {
         properties() {
             const properties = this.configInitials.properties.map(property => ({
                 value: property.name,
-                label: property.name,
+                label: this.locale(
+                    `properties.${property.type}.${property.name}`,
+                    this.readable(this.capitalize(property.name))
+                ),
                 type: property.type
             }));
             const result = {};

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -41,6 +41,16 @@
     min-width: 600px;
 }
 
+body.tablet .generic-personalization,
+body.mobile .generic-personalization {
+    min-width: 100%;
+}
+
+body.tablet .generic-personalization > .initials-images,
+body.mobile .generic-personalization > .initials-images {
+    display: flex;
+}
+
 .generic-personalization > .initials-images ::v-deep .initials-image {
     border-radius: 50%;
     margin-right: 30px;

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -170,7 +170,7 @@ export const Reference = {
     methods: {
         async refresh() {
             try {
-                this.groups = await this.$ripe.getLogicP({
+                this.groups = await this.$ripe.runLogicP({
                     brand: this.brand,
                     model: this.model,
                     method: "groups"

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -214,7 +214,7 @@ export const Reference = {
                     method: "groups"
                 });
             } catch (err) {
-                // if a build has no support for groups, had a default
+                // gives a default group if builds does not support logic
                 this.groups = ["main"];
             }
         },

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -268,8 +268,9 @@ export const Reference = {
 
             return []
                 .concat(
+                    position && group ? alias[`step::personalization:${position}:${group}`] : [],
                     position ? alias[`step::personalization:${position}`] : [],
-                    position ? alias[`step::personalization:${position}:${group}`] : [],
+                    group ? alias[`step::personalization:${group}`] : [],
                     alias["step::personalization"]
                 )
                 .filter(v => v !== undefined);

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -169,7 +169,6 @@ export const Reference = {
         },
         setState(state) {
             const initialsExtra = state.initialsExtra || {};
-            console.log("INITIALS EXTRA", JSON.stringify(initialsExtra));
             for (const name in initialsExtra) {
                 this.initialsText[name] = initialsExtra[name].initials || "";
                 this.fontData[name] =
@@ -178,7 +177,6 @@ export const Reference = {
                     "";
                 this.fontEngraving = this.fontData[name] || "";
             }
-            console.log("INITIALS EXTRA AFTER", JSON.stringify(this.initialsText), JSON.stringify(this.fontData));
         },
         getState() {
             return this.state;

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -181,6 +181,17 @@ export const Reference = {
         },
         setState(state) {
             const initialsExtra = state.initialsExtra || {};
+            // if there is no initialsExtra entries, clean all input data
+            // it occurs when the modal closes without the user applying
+            // the configuration
+            if (Object.keys(initialsExtra).length === 0) {
+                this.positionData = {};
+                this.styleData = {};
+                this.fontData = {};
+                this.initialsText = {};
+                return;
+            }
+
             for (const name in initialsExtra) {
                 this.$set(this.initialsText, name, initialsExtra[name].initials || "");
                 this.$set(

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -193,15 +193,14 @@ export const Reference = {
             }
 
             for (const name in initialsExtra) {
-                this.$set(this.initialsText, name, initialsExtra[name].initials || "");
-                this.$set(
-                    this.fontData,
-                    name,
+                const initials = initialsExtra[name].initials || "";
+                const engraving =
                     (initialsExtra[name].engraving &&
                         initialsExtra[name].engraving.split(":")[0]) ||
-                        ""
-                );
-                this.fontEngraving = this.fontData[name] || "";
+                    "";
+                this.$set(this.initialsText, name, initials);
+                this.$set(this.fontData, name, engraving);
+                this.fontEngraving = this.fontData[name];
             }
         },
         getState() {
@@ -299,7 +298,7 @@ export const Reference = {
             const position = this.positionData[group] || "";
             const personalizationAlias = [];
 
-            // gets viewports related to positions
+            // gets viewports related to the current position
             personalizationAlias.push.apply(
                 personalizationAlias,
                 alias[`step::personalization:${position}`]
@@ -307,6 +306,9 @@ export const Reference = {
             personalizationAlias.push.apply(personalizationAlias, alias["step::personalization"]);
 
             if (personalizationAlias.length === 0) return "";
+            // returns the first viewport for the step personalization
+            // if there is a viewport more specific to the current position
+            // it will be positioned first in the array
             return personalizationAlias.map(viewport => viewport.split("::")[1])[0];
         },
         __buildEngraving(group) {

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -218,14 +218,14 @@ export const Reference = {
 
                     ["font", "style"].forEach(propertyName => {
                         const property = this.propertiesData[group][propertyName];
-                        if (property) {
-                            text.push(
-                                this.locale(
-                                    `properties.${propertyName}.${property}`,
-                                    this.readable(this.capitalize(property))
-                                )
-                            );
-                        }
+                        if (!property) return;
+
+                        text.push(
+                            this.locale(
+                                `properties.${propertyName}.${property}`,
+                                this.readable(this.capitalize(property))
+                            )
+                        );
                     });
 
                     return text.join(" ");

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -182,11 +182,10 @@ export const Reference = {
         setState(state) {
             const initialsExtra = state.initialsExtra || {};
             for (const name in initialsExtra) {
-                this.initialsText[name] = initialsExtra[name].initials || "";
-                this.fontData[name] =
-                    (initialsExtra[name].engraving &&
+                this.$set(this.initialsText, name, initialsExtra[name].initials || "");
+                this.$set(this.fontData, name, (initialsExtra[name].engraving &&
                         initialsExtra[name].engraving.split(":")[0]) ||
-                    "";
+                    "");
                 this.fontEngraving = this.fontData[name] || "";
             }
         },

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -195,7 +195,10 @@ export const Reference = {
                 if (!initialsText) continue;
                 initials.push(initialsText);
 
-                const engraving = this.fontData[name]
+                // when entering with a null engraving,
+                // replace string null value so that it
+                // does not appear in tab message
+                const engraving = this.fontData[name] && this.fontData[name] !== "null"
                     ? this.locale(
                           "properties.font." + this.fontData[name].split(":")[0],
                           this.readable(this.capitalize(this.fontData[name]))

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -235,6 +235,7 @@ export const Reference = {
             group = group || Object.keys(this.propertiesData)[0];
             if (!group) return "";
             return Object.entries(this.propertiesData[group])
+                .filter(([type, value]) => Boolean(value))
                 .map(([type, value]) => `${type}:${value}`)
                 .join(".");
         },

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -150,6 +150,12 @@ export const Reference = {
                 this.$emit("changed", this);
             },
             deep: true
+        },
+        positionData: {
+            handler: function() {
+                this.$ripe.update();
+            },
+            deep: true
         }
     },
     mounted: async function() {
@@ -265,11 +271,15 @@ export const Reference = {
         },
         __getViewport(group) {
             const alias = this.$store.state.config.initials.$alias;
+            if (!alias) return "";
             const position = this.positionData[group] || "";
             const personalizationAlias = [];
 
             // gets viewports related to positions
-            personalizationAlias.push.apply(personalizationAlias, alias[`step::personalization:${position}`]);
+            personalizationAlias.push.apply(
+                personalizationAlias,
+                alias[`step::personalization:${position}`]
+            );
             personalizationAlias.push.apply(personalizationAlias, alias["step::personalization"]);
 
             if (personalizationAlias.length === 0) return "";

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -255,6 +255,8 @@ export const Reference = {
                 profiles.push(value);
             });
 
+            profiles.push(group);
+
             return {
                 initials: initials,
                 profile: profiles

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -183,9 +183,13 @@ export const Reference = {
             const initialsExtra = state.initialsExtra || {};
             for (const name in initialsExtra) {
                 this.$set(this.initialsText, name, initialsExtra[name].initials || "");
-                this.$set(this.fontData, name, (initialsExtra[name].engraving &&
+                this.$set(
+                    this.fontData,
+                    name,
+                    (initialsExtra[name].engraving &&
                         initialsExtra[name].engraving.split(":")[0]) ||
-                    "");
+                        ""
+                );
                 this.fontEngraving = this.fontData[name] || "";
             }
         },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/349 |
| Decisions | Changed `initials-images` to support updating when groups change. Support for one or multiple groups. It takes into account all the properties of a build (style, font, position) to apply the profiles. It takes into account the information in $alias regarding the viewport of `step::personalization` for the personalization modal images. Lastly, it uses the font and style properties to build and parse the engraving information. |
| Dependencies | • https://github.com/ripe-tech/ripe-sdk/pull/173 <br> • https://github.com/ripe-tech/ripe-white/pull/453 |
| Testing | • http://localhost:3000/?technical=1&brand=kirkwood&model=alligator_beya_loafer <br> • http://localhost:3000/?brand=swear&model=vyner <br> • http://localhost:3000/?brand=monica_vinader&model=baja_ft_br_g <br> • http://localhost:3000/?initials=A&engraving=black%3Astyle.jungle_love%3Afont&brand=hermes&model=h003369sv17&initials_extra=main%3AA%3Ablack%5C%3Astyle.jungle_love%5C%3Afont&p=body%3Asilk%3A17&p=shadow%3Adefault%3Adefault |
| Animated GIF | (colors are wrong, problem with the gifs) <br> ![kirkwood](https://user-images.githubusercontent.com/25725586/83162576-d6435e80-a101-11ea-83b0-39adf5243d6e.gif)![vyner](https://user-images.githubusercontent.com/25725586/83162618-dfccc680-a101-11ea-9435-005511eac148.gif) ![sergio_rossi](https://user-images.githubusercontent.com/25725586/83163657-3090ef00-a103-11ea-9d4b-0ce1ce974a5f.gif)<br>Mobile<br><img width="696" alt="Screenshot 2020-05-29 at 09 00 57" src="https://user-images.githubusercontent.com/25725586/83236268-261a3800-a18b-11ea-9d86-02e95b98fac5.png"> <br> Support for both font and style in engraving: <br> <img width="2142" alt="Screenshot 2020-05-29 at 16 11 48" src="https://user-images.githubusercontent.com/25725586/83275809-99419f80-a1c7-11ea-8075-788fcf02bb92.png"> <br> Mobile: <br> <img width="500" alt="Screenshot 2020-06-04 at 09 10 14" src="https://user-images.githubusercontent.com/25725586/83743290-6f1e3080-a652-11ea-8c57-2361f7c2423e.png"><img width="471" alt="Screenshot 2020-06-04 at 09 13 44" src="https://user-images.githubusercontent.com/25725586/83743293-6fb6c700-a652-11ea-904a-0d55b7f8dbf2.png"><img width="488" alt="Screenshot 2020-06-04 at 09 10 25" src="https://user-images.githubusercontent.com/25725586/83743294-6fb6c700-a652-11ea-8232-77b7d183bb83.png">|
