### PR TITLE
Fix text overflow in personalization button

### DIFF
--- a/vue/components/organisms/personalization/personalization.vue
+++ b/vue/components/organisms/personalization/personalization.vue
@@ -10,7 +10,7 @@
             v-on:click="showModal"
         >
             <h3>{{ "ripe_commons.personalization.personalization" | locale }}</h3>
-            <p>{{ buttonText | locale }}</p>
+            <p class="button-text">{{ buttonText | locale }}</p>
         </div>
         <modal ref="modal">
             <div v-show="enabled">
@@ -50,6 +50,12 @@
     background-color: transparent;
     border-color: transparent;
     pointer-events: none;
+}
+
+.personalization > .button-personalization > .button-text {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 .personalization ::v-deep .tabs {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Decisions | With the new generic-personalization, there could be personalizations that exceed the space of the button personalization. Without the fix, the text would appear bellow the button, outside of its limits. `Text-overflow ellipsis` was added. |
| Dependencies | -- |
| Screenshots | Example <br> Before: <br> <img width="1600" alt="Screenshot 2020-06-04 at 11 23 02" src="https://user-images.githubusercontent.com/25725586/83747766-071f1880-a659-11ea-9ec7-449a271c2f96.png"><br>After:<br><img width="1630" alt="Screenshot 2020-06-04 at 11 22 51" src="https://user-images.githubusercontent.com/25725586/83747769-08504580-a659-11ea-9cce-ada48ea5c9ba.png">|

