### PR TITLE
#467 Fixed restrictions alert not closing when undo button is clicked

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -473,7 +473,6 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
 
                 // pipes the ripe plugins events to the vue bus, allows
                 // so that UI components can "respond" to changes
-                self.ripe.bind("part", (...args) => this.$bus.trigger("part", ...args));
                 self.restrictionsPlugin.bind("restrictions", (...args) =>
                     this.$bus.trigger("restrictions", ...args)
                 );

--- a/js/base/main.js
+++ b/js/base/main.js
@@ -473,6 +473,7 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
 
                 // pipes the ripe plugins events to the vue bus, allows
                 // so that UI components can "respond" to changes
+                self.ripe.bind("part", (...args) => this.$bus.trigger("part", ...args));
                 self.restrictionsPlugin.bind("restrictions", (...args) =>
                     this.$bus.trigger("restrictions", ...args)
                 );

--- a/vue/components/molecules/restrictions-alert/restrictions-alert.vue
+++ b/vue/components/molecules/restrictions-alert/restrictions-alert.vue
@@ -77,10 +77,24 @@ export const RestrictionsAlert = {
             visible: false
         };
     },
-    mounted: function() {
-        this.$bus.bind("restrictions", (changes, newPart) => {
+    created: function() {
+        this.onRestrictions = this.$bus.bind("restrictions", (changes, newPart) => {
             this.visible = changes.length > 0;
         });
+
+        this.onConfig = this.$bus.bind("config", () => this.close());
+        this.onPart = this.$bus.bind("part", () => this.close());
+        this.onPart = this.$bus.bind("parts", () => this.close());
+        this.onInitials = this.$bus.bind("initials", () => this.close());
+        this.onInitialsExtra = this.$bus.bind("initials_extra", () => this.close());
+    },
+    destroyed: function() {
+        if (this.onRestrictions) this.$bus.unbind("restrictions", this.onRestrictions);
+        if (this.onMessage) this.$bus.unbind("message", this.onMessage);
+        if (this.onConfig) this.$bus.unbind("config", this.onConfig);
+        if (this.onPart) this.$bus.unbind("part", this.onPart);
+        if (this.onInitials) this.$bus.unbind("initials", this.onInitials);
+        if (this.onInitialsExtra) this.$bus.unbind("initials_extra", this.onInitialsExtra);
     },
     methods: {
         undo() {

--- a/vue/components/molecules/restrictions-alert/restrictions-alert.vue
+++ b/vue/components/molecules/restrictions-alert/restrictions-alert.vue
@@ -90,7 +90,6 @@ export const RestrictionsAlert = {
     },
     methods: {
         undo() {
-            this.close();
             this.$bus.trigger("undo");
         },
         close() {

--- a/vue/components/molecules/restrictions-alert/restrictions-alert.vue
+++ b/vue/components/molecules/restrictions-alert/restrictions-alert.vue
@@ -82,23 +82,15 @@ export const RestrictionsAlert = {
             this.visible = changes.length > 0;
         });
 
-        this.onConfig = this.$bus.bind("config", () => this.close());
-        this.onPart = this.$bus.bind("part", () => this.close());
-        this.onParts = this.$bus.bind("parts", () => this.close());
-        this.onInitials = this.$bus.bind("initials", () => this.close());
-        this.onInitialsExtra = this.$bus.bind("initials_extra", () => this.close());
+        this.onUndo = this.$bus.bind("undo", () => this.close());
     },
     destroyed: function() {
         if (this.onRestrictions) this.$bus.unbind("restrictions", this.onRestrictions);
-        if (this.onConfig) this.$bus.unbind("config", this.onConfig);
-        if (this.onPart) this.$bus.unbind("part", this.onPart);
-        if (this.onParts) this.$bus.unbind("parts", this.onParts);
-        if (this.onInitials) this.$bus.unbind("initials", this.onInitials);
-        if (this.onInitialsExtra) this.$bus.unbind("initials_extra", this.onInitialsExtra);
+        if (this.onUndo) this.$bus.unbind("undo", this.onUndo);
     },
     methods: {
         undo() {
-            this.visible = false;
+            this.close();
             this.$bus.trigger("undo");
         },
         close() {

--- a/vue/components/molecules/restrictions-alert/restrictions-alert.vue
+++ b/vue/components/molecules/restrictions-alert/restrictions-alert.vue
@@ -85,8 +85,8 @@ export const RestrictionsAlert = {
         this.onUndo = this.$bus.bind("undo", () => this.close());
     },
     destroyed: function() {
-        if (this.onRestrictions) this.$bus.unbind("restrictions", this.onRestrictions);
         if (this.onUndo) this.$bus.unbind("undo", this.onUndo);
+        if (this.onRestrictions) this.$bus.unbind("restrictions", this.onRestrictions);
     },
     methods: {
         undo() {

--- a/vue/components/molecules/restrictions-alert/restrictions-alert.vue
+++ b/vue/components/molecules/restrictions-alert/restrictions-alert.vue
@@ -84,15 +84,15 @@ export const RestrictionsAlert = {
 
         this.onConfig = this.$bus.bind("config", () => this.close());
         this.onPart = this.$bus.bind("part", () => this.close());
-        this.onPart = this.$bus.bind("parts", () => this.close());
+        this.onParts = this.$bus.bind("parts", () => this.close());
         this.onInitials = this.$bus.bind("initials", () => this.close());
         this.onInitialsExtra = this.$bus.bind("initials_extra", () => this.close());
     },
     destroyed: function() {
         if (this.onRestrictions) this.$bus.unbind("restrictions", this.onRestrictions);
-        if (this.onMessage) this.$bus.unbind("message", this.onMessage);
         if (this.onConfig) this.$bus.unbind("config", this.onConfig);
         if (this.onPart) this.$bus.unbind("part", this.onPart);
+        if (this.onParts) this.$bus.unbind("parts", this.onParts);
         if (this.onInitials) this.$bus.unbind("initials", this.onInitials);
         if (this.onInitialsExtra) this.$bus.unbind("initials_extra", this.onInitialsExtra);
     },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/467 |
| Dependencies | -- |
| Decisions | • Closing the restrictions alert when the `undo` event is triggered<br><br>• The approach to close the restrictions alert when an event related to a change in the customization is triggered wasn't followed because of the following order of events:<br>- Strass is selected<br>- Event `restrictions` is triggered (which makes the restrictions alert open)<br>- Event `part` is triggered (which would make the restrictions alert close)<br>So, given the order of the events, the restrictions alert will never open.<br><br>After discussing with @gcandal, we opted for this approach.|
| Animated GIF | **Before fix:**<br>![White-Restrictions_alert_doesnt_close_after_undo_bug](https://user-images.githubusercontent.com/22588915/84030709-64360980-a98c-11ea-8448-fa8ddb96c9a1.gif)<br><br>**After fix:**<br>![White-Restrictions_alert_closing_when_undo_clicked](https://user-images.githubusercontent.com/22588915/84052521-9a818200-a9a8-11ea-875b-258af34e59b7.gif) |