### PR TITLE
#122 Unit test for the restrictions-alert fix

### DIFF
--- a/vue/test/base.js
+++ b/vue/test/base.js
@@ -11,8 +11,7 @@ const localVue = testUtils.createLocalVue();
 localVue.use(plugins.busPlugin);
 localVue.use(components.install);
 localVue.component("global-events", globalEvents.default);
-localVue.filter("locale", mocks.locale);
-localVue.mixin(mocks.deviceMockMixin);
+localVue.use(mocks);
 
 /**
  * Initializes a mounted component.

--- a/vue/test/base.js
+++ b/vue/test/base.js
@@ -11,6 +11,7 @@ const localVue = testUtils.createLocalVue();
 localVue.use(plugins.busPlugin);
 localVue.use(components.install);
 localVue.component("global-events", globalEvents.default);
+localVue.filter("locale", mocks.locale);
 localVue.mixin(mocks.deviceMockMixin);
 
 /**

--- a/vue/test/base.js
+++ b/vue/test/base.js
@@ -1,6 +1,8 @@
 const testUtils = require("@vue/test-utils");
 const globalEvents = require("vue-global-events");
 
+const Ripe = require("ripe-sdk").Ripe;
+
 const plugins = require("../plugins");
 const components = require("../components");
 
@@ -8,6 +10,7 @@ const mocks = require("./mocks");
 
 const localVue = testUtils.createLocalVue();
 
+localVue.use(plugins.ripePlugin, new Ripe());
 localVue.use(plugins.busPlugin);
 localVue.use(components.install);
 localVue.component("global-events", globalEvents.default);

--- a/vue/test/base.js
+++ b/vue/test/base.js
@@ -10,7 +10,12 @@ const mocks = require("./mocks");
 
 const localVue = testUtils.createLocalVue();
 
-localVue.use(plugins.ripePlugin, new Ripe());
+const restrictions = [[{ color: "black" }, { color: "white" }]];
+const ripePlugins = [new Ripe.plugins.RestrictionsPlugin(restrictions)];
+const ripe = new Ripe(null, null, { plugins: ripePlugins });
+
+localVue.use(plugins.ripePlugin, ripe);
+// localVue.use(plugins.ripePlugin, new Ripe());
 localVue.use(plugins.busPlugin);
 localVue.use(components.install);
 localVue.component("global-events", globalEvents.default);

--- a/vue/test/base.js
+++ b/vue/test/base.js
@@ -1,8 +1,6 @@
 const testUtils = require("@vue/test-utils");
 const globalEvents = require("vue-global-events");
 
-const Ripe = require("ripe-sdk").Ripe;
-
 const plugins = require("../plugins");
 const components = require("../components");
 
@@ -10,12 +8,6 @@ const mocks = require("./mocks");
 
 const localVue = testUtils.createLocalVue();
 
-const restrictions = [[{ color: "black" }, { color: "white" }]];
-const ripePlugins = [new Ripe.plugins.RestrictionsPlugin(restrictions)];
-const ripe = new Ripe(null, null, { plugins: ripePlugins });
-
-localVue.use(plugins.ripePlugin, ripe);
-// localVue.use(plugins.ripePlugin, new Ripe());
 localVue.use(plugins.busPlugin);
 localVue.use(components.install);
 localVue.component("global-events", globalEvents.default);

--- a/vue/test/components/restrictions-alert/restrictions-alert.test.js
+++ b/vue/test/components/restrictions-alert/restrictions-alert.test.js
@@ -2,30 +2,44 @@ const assert = require("assert");
 const base = require("../../base");
 
 describe("Restrictions Alert", () => {
-    it("Closes on Undo", () => {
-        const changes = ["change1", "change2"];
-        const partSet = null;
-
+    it("Open on restrictions", () => {
         const component = base.getComponent("RestrictionsAlert");
-
         assert.strictEqual(component.vm.$data.visible, false);
 
-        component.vm.$bus.trigger("restrictions", changes, partSet);
+        component.vm.$bus.trigger("restrictions", ["change1", "change2"]);
         assert.strictEqual(component.vm.$data.visible, true);
 
         component.vm.$bus.trigger("undo");
         assert.strictEqual(component.vm.$data.visible, false);
     });
 
-    it('Doesn\'t open when an "restrictions" event, with no changes, is triggered', () => {
-        const changes = [];
-        const partSet = null;
-
+    it("Doesn't open without restrictions", () => {
         const component = base.getComponent("RestrictionsAlert");
-
         assert.strictEqual(component.vm.$data.visible, false);
 
-        component.vm.$bus.trigger("restrictions", changes, partSet);
+        component.vm.$bus.trigger("restrictions", []);
+        assert.strictEqual(component.vm.$data.visible, false);
+    });
+
+    it("Closes on undo", () => {
+        const component = base.getComponent("RestrictionsAlert");
+        assert.strictEqual(component.vm.$data.visible, false);
+
+        component.vm.$bus.trigger("restrictions", ["change1", "change2"]);
+        assert.strictEqual(component.vm.$data.visible, true);
+
+        component.vm.$bus.trigger("undo");
+        assert.strictEqual(component.vm.$data.visible, false);
+    });
+
+    it("Closes on no restrictions", () => {
+        const component = base.getComponent("RestrictionsAlert");
+        assert.strictEqual(component.vm.$data.visible, false);
+
+        component.vm.$bus.trigger("restrictions", ["change1", "change2"]);
+        assert.strictEqual(component.vm.$data.visible, true);
+
+        component.vm.$bus.trigger("restrictions", []);
         assert.strictEqual(component.vm.$data.visible, false);
     });
 });

--- a/vue/test/components/restrictions-alert/restrictions-alert.test.js
+++ b/vue/test/components/restrictions-alert/restrictions-alert.test.js
@@ -5,9 +5,19 @@ describe("Restrictions Alert", () => {
     it("Closes on Undo", () => {
         const component = base.getComponent("RestrictionsAlert");
         
-        console.log("\n\n--------testing stuff:\n");
-        console.log("ripe:", component.vm.$ripe)
-        console.log("bus:", component.vm.$bus)
+
+
+        console.log("\n\n--------\n", "testing stuff:\n");
+
+        // component.vm.$ripe.plugins[0] is the "RestrictionsPlugin"
+        component.vm.$ripe.plugins[0].bind("restrictions", (...args) =>
+            component.vm.$bus.trigger("restrictions", ...args)
+        );
+        component.vm.$bus.bind("restrictions", (changes, partSet) =>
+            console.log("Testing restrictions event:", changes, partSet)
+        ); // TODO remove
+
+        component.vm.$ripe.plugins[0]._applyRestrictions("name test", "value test");
 
 
 

--- a/vue/test/components/restrictions-alert/restrictions-alert.test.js
+++ b/vue/test/components/restrictions-alert/restrictions-alert.test.js
@@ -1,7 +1,7 @@
 const assert = require("assert");
 const base = require("../../base");
 
-describe("Restrictions Alert", () => {
+describe("RestrictionsAlert", () => {
     it("should open on restrictions", () => {
         const component = base.getComponent("RestrictionsAlert");
         assert.strictEqual(component.vm.$data.visible, false);

--- a/vue/test/components/restrictions-alert/restrictions-alert.test.js
+++ b/vue/test/components/restrictions-alert/restrictions-alert.test.js
@@ -2,7 +2,7 @@ const assert = require("assert");
 const base = require("../../base");
 
 describe("Restrictions Alert", () => {
-    it("Open on restrictions", () => {
+    it("should open on restrictions", () => {
         const component = base.getComponent("RestrictionsAlert");
         assert.strictEqual(component.vm.$data.visible, false);
 
@@ -13,7 +13,7 @@ describe("Restrictions Alert", () => {
         assert.strictEqual(component.vm.$data.visible, false);
     });
 
-    it("Doesn't open without restrictions", () => {
+    it("should not open without restrictions", () => {
         const component = base.getComponent("RestrictionsAlert");
         assert.strictEqual(component.vm.$data.visible, false);
 
@@ -21,7 +21,7 @@ describe("Restrictions Alert", () => {
         assert.strictEqual(component.vm.$data.visible, false);
     });
 
-    it("Closes on undo", () => {
+    it("should close on undo", () => {
         const component = base.getComponent("RestrictionsAlert");
         assert.strictEqual(component.vm.$data.visible, false);
 
@@ -32,7 +32,7 @@ describe("Restrictions Alert", () => {
         assert.strictEqual(component.vm.$data.visible, false);
     });
 
-    it("Closes on no restrictions", () => {
+    it("should close on no restrictions", () => {
         const component = base.getComponent("RestrictionsAlert");
         assert.strictEqual(component.vm.$data.visible, false);
 

--- a/vue/test/components/restrictions-alert/restrictions-alert.test.js
+++ b/vue/test/components/restrictions-alert/restrictions-alert.test.js
@@ -16,4 +16,16 @@ describe("Restrictions Alert", () => {
         component.vm.$bus.trigger("undo");
         assert.strictEqual(component.vm.$data.visible, false);
     });
+
+    it('Doesn\'t open when an "restrictions" event with no changes is triggered', () => {
+        const changes = [];
+        const partSet = null;
+
+        const component = base.getComponent("RestrictionsAlert");
+
+        assert.strictEqual(component.vm.$data.visible, false);
+
+        component.vm.$bus.trigger("restrictions", changes, partSet);
+        assert.strictEqual(component.vm.$data.visible, false);
+    });
 });

--- a/vue/test/components/restrictions-alert/restrictions-alert.test.js
+++ b/vue/test/components/restrictions-alert/restrictions-alert.test.js
@@ -1,0 +1,24 @@
+const assert = require("assert");
+const base = require("../../base");
+
+describe("Restrictions Alert", () => {
+    it("Closes on Undo", () => {
+        const component = base.getComponent("RestrictionsAlert");
+        
+        console.log("\n\n--------testing stuff:\n");
+        console.log("ripe:", component.vm.$ripe)
+        console.log("bus:", component.vm.$bus)
+
+
+
+
+
+
+        // TODO
+        // - event "restrictions"
+        // - see if alert is open
+        // - event "undo"
+        // - see if alert is closed
+        assert.strictEqual(true, true);
+    });
+});

--- a/vue/test/components/restrictions-alert/restrictions-alert.test.js
+++ b/vue/test/components/restrictions-alert/restrictions-alert.test.js
@@ -3,32 +3,17 @@ const base = require("../../base");
 
 describe("Restrictions Alert", () => {
     it("Closes on Undo", () => {
+        const changes = ["change1", "change2"];
+        const partSet = null;
+
         const component = base.getComponent("RestrictionsAlert");
-        
 
+        assert.strictEqual(component.vm.$data.visible, false);
 
-        console.log("\n\n--------\n", "testing stuff:\n");
+        component.vm.$bus.trigger("restrictions", changes, partSet);
+        assert.strictEqual(component.vm.$data.visible, true);
 
-        // component.vm.$ripe.plugins[0] is the "RestrictionsPlugin"
-        component.vm.$ripe.plugins[0].bind("restrictions", (...args) =>
-            component.vm.$bus.trigger("restrictions", ...args)
-        );
-        component.vm.$bus.bind("restrictions", (changes, partSet) =>
-            console.log("Testing restrictions event:", changes, partSet)
-        ); // TODO remove
-
-        component.vm.$ripe.plugins[0]._applyRestrictions("name test", "value test");
-
-
-
-
-
-
-        // TODO
-        // - event "restrictions"
-        // - see if alert is open
-        // - event "undo"
-        // - see if alert is closed
-        assert.strictEqual(true, true);
+        component.vm.$bus.trigger("undo");
+        assert.strictEqual(component.vm.$data.visible, false);
     });
 });

--- a/vue/test/components/restrictions-alert/restrictions-alert.test.js
+++ b/vue/test/components/restrictions-alert/restrictions-alert.test.js
@@ -17,7 +17,7 @@ describe("Restrictions Alert", () => {
         assert.strictEqual(component.vm.$data.visible, false);
     });
 
-    it('Doesn\'t open when an "restrictions" event with no changes is triggered', () => {
+    it('Doesn\'t open when an "restrictions" event, with no changes, is triggered', () => {
         const changes = [];
         const partSet = null;
 

--- a/vue/test/mocks/filters/index.js
+++ b/vue/test/mocks/filters/index.js
@@ -1,0 +1,1 @@
+export * from "./locale";

--- a/vue/test/mocks/filters/index.js
+++ b/vue/test/mocks/filters/index.js
@@ -1,1 +1,9 @@
-export * from "./locale";
+import { locale } from "./locale";
+
+export const install = Vue => {
+    Vue.filter("locale", locale);
+};
+
+export { locale };
+
+export default install;

--- a/vue/test/mocks/filters/locale.js
+++ b/vue/test/mocks/filters/locale.js
@@ -1,0 +1,3 @@
+export const locale = function(value, defaultValue) {
+    return value || defaultValue;
+};

--- a/vue/test/mocks/index.js
+++ b/vue/test/mocks/index.js
@@ -1,2 +1,11 @@
-export * from "./filters";
-export * from "./mixins";
+import filters from "./filters";
+import mixins from "./mixins";
+
+export const install = Vue => {
+    Vue.use(filters);
+    Vue.use(mixins);
+};
+
+export { filters, mixins };
+
+export default install;

--- a/vue/test/mocks/index.js
+++ b/vue/test/mocks/index.js
@@ -1,1 +1,2 @@
+export * from "./filters";
 export * from "./mixins";

--- a/vue/test/mocks/mixins/index.js
+++ b/vue/test/mocks/mixins/index.js
@@ -1,1 +1,9 @@
-export * from "./device";
+import { deviceMockMixin } from "./device";
+
+export const install = Vue => {
+    Vue.mixin(deviceMockMixin);
+};
+
+export { deviceMockMixin };
+
+export default install;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-commons-pluginus/issues/122 |
| Decisions | • Added the test "Closes on Undo" for the `restrictions-alert` component. The test goes as follows: <br>&nbsp;&nbsp;&nbsp;&nbsp;- Triggers event "restrictions" with changes to open the `restritions-alert` <br>&nbsp;&nbsp;&nbsp;&nbsp;- Triggers the event "undo" which will make the `restritions-alert` close<br>• Added the test "'Doesn't open when an "restrictions" event, with no changes, is triggered'" for the `restrictions-alert` component. The test goes as follows: <br>&nbsp;&nbsp;&nbsp;&nbsp;- Triggers event "restrictions" with no changes <br>&nbsp;&nbsp;&nbsp;&nbsp;- The `restritions-alert` shouldn't open after the event |
| Animated GIF | ![tests_passing](https://user-images.githubusercontent.com/22588915/85040562-da065600-b180-11ea-9c7c-a64782de1dce.gif) |
