### PR TITLE
#116: Check if personalization's dynamic component is null

### DIFF
--- a/vue/components/organisms/personalization/personalization.vue
+++ b/vue/components/organisms/personalization/personalization.vue
@@ -18,6 +18,7 @@
             <div v-show="enabled">
                 <h3 class="title">{{ "ripe_commons.personalization.personalization" | locale }}</h3>
                 <component
+                    v-if="form"
                     v-bind:is="form"
                     ref="form"
                     v-bind:key="formKey"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to #116  |
| Decisions |  Added v-if that prevents mounting the dynamic component if the form is null. This will be necessary for the generic-personalization unit tests. Without this, when mounting the personalization component, a an error `Error in render: "TypeError: Cannot read property 'template' of null" ` like this is shown, since the `form` is `null`. This does not change the behaviour of the component. |
| Animated GIF |  -- |
