### PR TITLE
Export the Vue class

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -567,3 +567,5 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
         alert(err.message ? err.message : String(err));
     }
 }
+
+export const VueClass = Vue;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Some operations, such as dynamically mounting components, require access to the Vue class. Because we're defining it in ripe-commons-pluginus, clients should have a way to access the original Vue class, in order to be able to use a single class rather than repeating `import Vue from "vue";`, which is severely limited because it doesn't have access to components or mixins registered by ripe-commons-pluginus. |