### PR TITLE
#503 Add semantic classes to generic personalization

### DIFF
--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -18,7 +18,7 @@
                     v-bind:key="type"
                 >
                     <select-ripe
-                        v-bind:class="(`properties.${type}`, readable(type)) | locale"
+                        v-bind:class="type"
                         v-bind:placeholder="`ripe_commons.personalization.select.${type}` | locale"
                         v-bind:options="options"
                         v-bind:value="propertiesData[group][type]"

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -18,7 +18,7 @@
                     v-bind:key="type"
                 >
                     <select-ripe
-                        v-bind:class="type"
+                        class="select-type"
                         v-bind:placeholder="`ripe_commons.personalization.select.${type}` | locale"
                         v-bind:options="options"
                         v-bind:value="propertiesData[group][type]"
@@ -30,7 +30,7 @@
                     v-bind:header-size="'large'"
                 >
                     <input-ripe
-                        class="add-initials"
+                        class="input-initials"
                         v-bind:placeholder="'ripe_commons.personalization.add_initials' | locale"
                         v-bind:value.sync="initialsText[group]"
                     />

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -18,6 +18,7 @@
                     v-bind:key="type"
                 >
                     <select-ripe
+                        v-bind:class="(`properties.${type}`, readable(type)) | locale"
                         v-bind:placeholder="`ripe_commons.personalization.select.${type}` | locale"
                         v-bind:options="options"
                         v-bind:value="propertiesData[group][type]"
@@ -29,6 +30,7 @@
                     v-bind:header-size="'large'"
                 >
                     <input-ripe
+                        class="add-initials"
                         v-bind:placeholder="'ripe_commons.personalization.add_initials' | locale"
                         v-bind:value.sync="initialsText[group]"
                     />


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/503 |
| Decisions | Add semantic classes to inputs for testing purposes. |
