### PR TITLE
Fix generic plugin select class name

### DIFF
--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -18,7 +18,7 @@
                     v-bind:key="type"
                 >
                     <select-ripe
-                        class="select-type"
+                        v-bind:class="`select-${type}`"
                         v-bind:placeholder="`ripe_commons.personalization.select.${type}` | locale"
                         v-bind:options="options"
                         v-bind:value="propertiesData[group][type]"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Fixes a regression caused in https://github.com/ripe-tech/ripe-commons-pluginus/commit/9f48dfa20d74cf79431f781cf4e4000ffdc53536 where we lost the type of the select (eg `font`, `position`) in the name of the class. This is not being used in any test, so no adaptations need to be made. |
