### PR TITLE
Fix engraving for generic personalization

### DIFF
--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -261,14 +261,14 @@ export const Reference = {
             if (!group) return "";
             return Object.entries(this.propertiesData[group])
                 .filter(([type, value]) => Boolean(value))
-                .map(([type, value]) => `${type}:${value}`)
+                .map(([type, value]) => `${value}:${type}`)
                 .join(".");
         },
         engravingToProperties(engraving, group) {
-            engraving.split(".").map(engravingPart => {
-                const [property, value] = engravingPart.split(":", 2);
+            const { valuesM } = this.$ripe.parseEngraving(engraving);
+            Object.entries(valuesM).forEach(([property, value]) => {
                 this.onValueUpdate(value, group, property);
-            });
+            })
         },
         onValueUpdate(value, group, type) {
             const newProperties = { ...this.propertiesData };

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -268,7 +268,7 @@ export const Reference = {
             const { valuesM } = this.$ripe.parseEngraving(engraving);
             Object.entries(valuesM).forEach(([property, value]) => {
                 this.onValueUpdate(value, group, property);
-            })
+            });
         },
         onValueUpdate(value, group, type) {
             const newProperties = { ...this.propertiesData };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | The engraving-from-properties generation was wrong, as it was using a `propertyType:propertyValue` format, when it [should be the opposite](https://github.com/ripe-tech/ripe-core/blob/c10268ae18bed898a296f3fe7fb5bb1187ea5eca/src/ripe_core/test/controllers/web/adapter.py#L406). The image was still correctly generated because we were using a custom (and buggy) `parseEngraving` implementation. In practice, this changes nothing except that created orders will have a proper `engraving`. |
