### PR TITLE
Thumbnails groups component

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -7,16 +7,17 @@ import { install as RipeCommonsPluginusVue, plugins } from "../vue";
 
 import "./styles.css";
 
+Vue.use(Vuex);
+
 // initializes the event bus that will be used for
 // UI related communication between the components
 Vue.use(plugins.busPlugin);
 
-Vue.use(Vuex);
-Vue.prototype.$ripe = new Ripe("swear", "vyner");
-
 // initializes the main commons plugins structure
 // registering all of its components
 Vue.use(RipeCommonsPluginusVue);
+
+Vue.prototype.$ripe = new Ripe("swear", "vyner");
 
 const req = require.context("../vue", true, /\.stories\.js$/);
 function loadStories() {

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -17,7 +17,7 @@ Vue.use(plugins.busPlugin);
 // registering all of its components
 Vue.use(RipeCommonsPluginusVue);
 
-Vue.prototype.$ripe = new Ripe("sergio_rossi", "sr1_pump075");
+Vue.prototype.$ripe = new Ripe();
 
 const req = require.context("../vue", true, /\.stories\.js$/);
 function loadStories() {

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,12 +1,14 @@
 import Vue from "vue";
-import { configure } from "@storybook/vue";
 import Vuex from "vuex";
+import { configure } from "@storybook/vue";
 import { Ripe } from "ripe-sdk";
 
 import { install as RipeCommonsPluginusVue, plugins } from "../vue";
 
 import "./styles.css";
 
+// makes use of Vuex to make use of things like
+// data store (for some of the components)
 Vue.use(Vuex);
 
 // initializes the event bus that will be used for
@@ -17,6 +19,8 @@ Vue.use(plugins.busPlugin);
 // registering all of its components
 Vue.use(RipeCommonsPluginusVue);
 
+// creates the RIPE instance that is going to be used
+// through the Storybook "testing"
 Vue.prototype.$ripe = new Ripe();
 
 const req = require.context("../vue", true, /\.stories\.js$/);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -17,7 +17,7 @@ Vue.use(plugins.busPlugin);
 // registering all of its components
 Vue.use(RipeCommonsPluginusVue);
 
-Vue.prototype.$ripe = new Ripe("swear", "vyner");
+Vue.prototype.$ripe = new Ripe("sergio_rossi", "sr1_pump075");
 
 const req = require.context("../vue", true, /\.stories\.js$/);
 function loadStories() {

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,5 +1,7 @@
 import Vue from "vue";
 import { configure } from "@storybook/vue";
+import Vuex from "vuex";
+import { Ripe } from "ripe-sdk";
 
 import { install as RipeCommonsPluginusVue, plugins } from "../vue";
 
@@ -8,6 +10,9 @@ import "./styles.css";
 // initializes the event bus that will be used for
 // UI related communication between the components
 Vue.use(plugins.busPlugin);
+
+Vue.use(Vuex);
+Vue.prototype.$ripe = new Ripe("swear", "vyner");
 
 // initializes the main commons plugins structure
 // registering all of its components

--- a/vue/components/molecules/index.js
+++ b/vue/components/molecules/index.js
@@ -20,6 +20,16 @@ const install = Vue => {
     Vue.component("thumbnails-groups", ThumbnailsGroups);
 };
 
-export { Ask, ComponentPlugin, Keyboard, Modal, RestrictionsAlert, Tab, Tabs, Thumbnails, ThumbnailsGroups };
+export {
+    Ask,
+    ComponentPlugin,
+    Keyboard,
+    Modal,
+    RestrictionsAlert,
+    Tab,
+    Tabs,
+    Thumbnails,
+    ThumbnailsGroups
+};
 
 export default install;

--- a/vue/components/molecules/index.js
+++ b/vue/components/molecules/index.js
@@ -6,6 +6,7 @@ import { RestrictionsAlert } from "./restrictions-alert/restrictions-alert.vue";
 import { Tab } from "./tabs/tab.vue";
 import { Tabs } from "./tabs/tabs.vue";
 import { Thumbnails } from "./thumbnails/thumbnails.vue";
+import { ThumbnailsGroups } from "./thumbnails-groups/thumbnails-groups.vue";
 
 const install = Vue => {
     Vue.component("ask", Ask);
@@ -16,8 +17,9 @@ const install = Vue => {
     Vue.component("tab", Tab);
     Vue.component("tabs", Tabs);
     Vue.component("thumbnails", Thumbnails);
+    Vue.component("thumbnails-groups", ThumbnailsGroups);
 };
 
-export { Ask, ComponentPlugin, Keyboard, Modal, RestrictionsAlert, Tab, Tabs, Thumbnails };
+export { Ask, ComponentPlugin, Keyboard, Modal, RestrictionsAlert, Tab, Tabs, Thumbnails, ThumbnailsGroups };
 
 export default install;

--- a/vue/components/molecules/thumbnails-groups/index.js
+++ b/vue/components/molecules/thumbnails-groups/index.js
@@ -1,0 +1,1 @@
+export { ThumbnailsGroups } from "./thumbnails-groups.vue";

--- a/vue/components/molecules/thumbnails-groups/thumbnails-groups.stories.js
+++ b/vue/components/molecules/thumbnails-groups/thumbnails-groups.stories.js
@@ -21,8 +21,10 @@ storiesOf("Molecules", module)
                 model: "vyner",
                 personalization: {
                     initials: "AB",
+                    engraving: null,
                     initialsExtra: {
                         main: {
+                            engraving: null,
                             initials: "AB"
                         }
                     }

--- a/vue/components/molecules/thumbnails-groups/thumbnails-groups.stories.js
+++ b/vue/components/molecules/thumbnails-groups/thumbnails-groups.stories.js
@@ -1,0 +1,58 @@
+import { storiesOf } from "@storybook/vue";
+import Vuex from "vuex";
+import { withKnobs } from "@storybook/addon-knobs";
+
+storiesOf("Molecules", module)
+    .addDecorator(withKnobs)
+    .add("Thumbnails Group", () => ({
+        props: {
+            groups: {
+                type: Array,
+                default: ["main"]
+            },
+            activeGroup: {
+                type: String,
+                default: "main"
+            }
+        },
+        store: new Vuex.Store({
+            state: {
+                brand: "gucci",
+                model: "wool_sweater",
+                personalization: {
+                    initialsExtra: {
+                        sx: {
+                            initials: "123",
+                            engraving: "deco:font.outside:position.azzurro:style"
+                        },
+                        dx: {
+                            initials: "abc",
+                            engraving: "script:font.outside:position"
+                        }
+                    }
+                },
+                config: {
+                    initials: {
+                        properties: [
+                            { name: "deco", type: "font" },
+                            { name: "script", type: "font" },
+                            { name: "outside", type: "position" },
+                            { name: "oro", type: "style" },
+                            { name: "argento", type: "style" },
+                            { name: "verde", type: "style" },
+                            { name: "rosa", type: "style" },
+                            { name: "arancione", type: "style" },
+                            { name: "azzurro", type: "style" }
+                        ]
+                    }
+                }
+            }
+        }),
+        template: `
+            <div>
+                <thumbnails-groups
+                    v-bind:groups="groups"
+                    v-bind:active-group="activeGroup" />
+            </div>
+        `
+    }));

--- a/vue/components/molecules/thumbnails-groups/thumbnails-groups.stories.js
+++ b/vue/components/molecules/thumbnails-groups/thumbnails-groups.stories.js
@@ -8,51 +8,47 @@ storiesOf("Molecules", module)
         props: {
             groups: {
                 type: Array,
-                default: ["main"]
+                default: ["left", "right"]
             },
             activeGroup: {
                 type: String,
-                default: "main"
+                default: "left"
             }
         },
         store: new Vuex.Store({
             state: {
-                brand: "gucci",
-                model: "wool_sweater",
-                personalization: {
-                    initialsExtra: {
-                        sx: {
-                            initials: "123",
-                            engraving: "deco:font.outside:position.azzurro:style"
-                        },
-                        dx: {
-                            initials: "abc",
-                            engraving: "script:font.outside:position"
-                        }
-                    }
-                },
+                brand: "sergio_rossi",
+                model: "sr1_pump075",
+                personalization: {},
                 config: {
                     initials: {
-                        properties: [
-                            { name: "deco", type: "font" },
-                            { name: "script", type: "font" },
-                            { name: "outside", type: "position" },
-                            { name: "oro", type: "style" },
-                            { name: "argento", type: "style" },
-                            { name: "verde", type: "style" },
-                            { name: "rosa", type: "style" },
-                            { name: "arancione", type: "style" },
-                            { name: "azzurro", type: "style" }
-                        ]
+                        $alias: {
+                            report: ["viewport::medium"],
+                            "report:crystal:left": ["viewport::crystal:left:medium"],
+                            "report:crystal:right": ["viewport::crystal:right:medium"],
+                            "report:left": ["viewport::left:medium"],
+                            "report:right": ["viewport::right:medium"],
+                            "step::personalization": ["viewport::large"],
+                            "step::personalization:crystal:left": ["viewport::crystal:left:large"],
+                            "step::personalization:crystal:right": [
+                                "viewport::crystal:right:large"
+                            ],
+                            "step::personalization:left": ["viewport::left:large"],
+                            "step::personalization:right": ["viewport::right:large"],
+                            "step::size": ["viewport::medium"],
+                            "step::size:crystal:left": ["viewport::crystal:left:medium"],
+                            "step::size:crystal:right": ["viewport::crystal:right:medium"],
+                            "step::size:left": ["viewport::left:medium"],
+                            "step::size:right": ["viewport::right:medium"]
+                        }
                     }
                 }
             }
         }),
         template: `
-            <div>
                 <thumbnails-groups
+                    v-bind:size="204"
                     v-bind:groups="groups"
                     v-bind:active-group="activeGroup" />
-            </div>
         `
     }));

--- a/vue/components/molecules/thumbnails-groups/thumbnails-groups.stories.js
+++ b/vue/components/molecules/thumbnails-groups/thumbnails-groups.stories.js
@@ -4,7 +4,7 @@ import { withKnobs } from "@storybook/addon-knobs";
 
 storiesOf("Molecules", module)
     .addDecorator(withKnobs)
-    .add("Thumbnails Group", () => ({
+    .add("Thumbnails Groups", () => ({
         props: {
             groups: {
                 type: Array,
@@ -44,9 +44,9 @@ storiesOf("Molecules", module)
             await this.$ripe.config("swear", "vyner");
         },
         template: `
-                <thumbnails-groups
-                    v-bind:size="204"
-                    v-bind:groups="groups"
-                    v-bind:active-group="activeGroup" />
+            <thumbnails-groups
+                v-bind:size="204"
+                v-bind:groups="groups"
+                v-bind:active-group="activeGroup" />
         `
     }));

--- a/vue/components/molecules/thumbnails-groups/thumbnails-groups.stories.js
+++ b/vue/components/molecules/thumbnails-groups/thumbnails-groups.stories.js
@@ -8,43 +8,39 @@ storiesOf("Molecules", module)
         props: {
             groups: {
                 type: Array,
-                default: ["left", "right"]
+                default: ["main"]
             },
             activeGroup: {
                 type: String,
-                default: "left"
+                default: "main"
             }
         },
         store: new Vuex.Store({
             state: {
-                brand: "sergio_rossi",
-                model: "sr1_pump075",
-                personalization: {},
+                brand: "swear",
+                model: "vyner",
+                personalization: {
+                    initials: "AB",
+                    initialsExtra: {
+                        main: {
+                            initials: "AB"
+                        }
+                    }
+                },
                 config: {
                     initials: {
                         $alias: {
                             report: ["viewport::medium"],
-                            "report:crystal:left": ["viewport::crystal:left:medium"],
-                            "report:crystal:right": ["viewport::crystal:right:medium"],
-                            "report:left": ["viewport::left:medium"],
-                            "report:right": ["viewport::right:medium"],
                             "step::personalization": ["viewport::large"],
-                            "step::personalization:crystal:left": ["viewport::crystal:left:large"],
-                            "step::personalization:crystal:right": [
-                                "viewport::crystal:right:large"
-                            ],
-                            "step::personalization:left": ["viewport::left:large"],
-                            "step::personalization:right": ["viewport::right:large"],
-                            "step::size": ["viewport::medium"],
-                            "step::size:crystal:left": ["viewport::crystal:left:medium"],
-                            "step::size:crystal:right": ["viewport::crystal:right:medium"],
-                            "step::size:left": ["viewport::left:medium"],
-                            "step::size:right": ["viewport::right:medium"]
+                            "step::size": ["viewport::medium"]
                         }
                     }
                 }
             }
         }),
+        mounted: async function() {
+            await this.$ripe.config("swear", "vyner");
+        },
         template: `
                 <thumbnails-groups
                     v-bind:size="204"

--- a/vue/components/molecules/thumbnails-groups/thumbnails-groups.vue
+++ b/vue/components/molecules/thumbnails-groups/thumbnails-groups.vue
@@ -6,8 +6,8 @@
         v-bind:active-group="activeGroup"
         v-bind:groups="groups"
         v-bind:initials-builder="__initialsBuilder"
-        v-on:image-selected="onImageSelected"
         ref="thumbnailsContainer"
+        v-on:image-selected="onImageSelected"
     />
 </template>
 
@@ -42,7 +42,7 @@ export const ThumbnailsGroups = {
     data: function() {
         return {
             activeGroupData: this.activeGroup
-        }
+        };
     },
     computed: {
         brand() {

--- a/vue/components/molecules/thumbnails-groups/thumbnails-groups.vue
+++ b/vue/components/molecules/thumbnails-groups/thumbnails-groups.vue
@@ -1,0 +1,108 @@
+<template>
+    <initials-images
+        class="thumbnails thumbnails-groups"
+        v-bind:brand="brand"
+        v-bind:model="model"
+        v-bind:active-group="activeGroup"
+        v-bind:groups="groups"
+        v-bind:initials-builder="__initialsBuilder"
+        v-on:image-selected="onImageSelected"
+        ref="thumbnailsContainer"
+    />
+</template>
+
+<style lang="scss" scoped>
+.thumbnails.thumbnails-groups ::v-deep .initials-image {
+    display: block;
+    height: initial;
+}
+</style>
+
+<script>
+export const ThumbnailsGroups = {
+    name: "thumbnails-groups",
+    props: {
+        activeGroup: {
+            type: String,
+            required: true
+        },
+        groups: {
+            type: Array,
+            required: true
+        },
+        size: {
+            type: Number,
+            default: null
+        },
+        crop: {
+            type: Boolean,
+            default: null
+        }
+    },
+    data: function() {
+        return {
+            activeGroupData: this.activeGroup
+        }
+    },
+    computed: {
+        brand() {
+            return this.$store.state.brand;
+        },
+        model() {
+            return this.$store.state.model;
+        },
+        configInitials() {
+            return this.$store.state.config.initials;
+        }
+    },
+    watch: {
+        activeGroup(value) {
+            this.activeGroupData = value;
+        },
+        activeGroupData(value) {
+            this.$emit("update:active-group", value);
+        }
+    },
+    methods: {
+        onImageSelected(group) {
+            this.activeGroupData = group;
+        },
+        __initialsBuilder(initials, engraving, element) {
+            const group = element.getAttribute("data-group");
+            const properties = engraving
+                ? this.$ripe.parseEngraving(engraving, this.configInitials.properties).valuesM
+                : {};
+            const profiles = this.__getPersonalizationProfiles(group, properties);
+
+            Object.entries(properties).forEach(([type, value]) => {
+                this.groups.length > 1 && profiles.push(value + ":" + group);
+                profiles.push(value);
+            });
+
+            profiles.push(group);
+
+            return {
+                initials: initials || "$empty",
+                profile: profiles
+            };
+        },
+        __getPersonalizationProfiles(group, properties) {
+            const alias = this.configInitials.$alias;
+            if (!alias) return [];
+
+            const position = properties.position;
+
+            return []
+                .concat(
+                    position && group ? alias[`step::personalization:${position}:${group}`] : [],
+                    position ? alias[`step::personalization:${position}`] : [],
+                    group ? alias[`step::personalization:${group}`] : [],
+                    alias["step::personalization"]
+                )
+                .filter(v => v !== undefined);
+        }
+    }
+};
+
+export default ThumbnailsGroups;
+</script>


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Add a component that represents a set of thumbnails, where each one is a different initials group. This is equivalent to `thumbnails` but for groups instead of frames. |
| Issue | https://github.com/ripe-tech/ripe-white/issues/531 |
| Animated GIF | ![](http://g.recordit.co/kbvwHE4EnP.gif) | 