### PR TITLE
#84: InitialsBuilder inside 3DB support

### DIFF
--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -50,7 +50,7 @@ export const InitialsImages = {
         },
         context: {
             type: Array,
-            default: ["step::personalization"]
+            default: () => ["step::personalization"]
         }
     },
     data: function() {

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -48,9 +48,9 @@ export const InitialsImages = {
             type: Function,
             default: null
         },
-        contextGetter: {
-            type: Function,
-            default: null
+        context: {
+            type: Array,
+            default: ["step::personalization"]
         }
     },
     data: function() {
@@ -63,6 +63,13 @@ export const InitialsImages = {
         async groups(value) {
             await this.unbindImages();
             await this.bindImages();
+        },
+        context(value) {
+            if (!value.length) return;
+            for (const image of this.initialsImages) {
+                console.log(image);
+                image.setContext(value);
+            }
         }
     },
     mounted: async function() {
@@ -87,7 +94,7 @@ export const InitialsImages = {
                     showInitials: true,
                     initialsGroup: initialsImage.dataset.group,
                     baseInitialsBuilder: this.initialsBuilder,
-                    context: this.contextGetter || this.__getContext
+                    context: this.context
                 });
                 this.initialsImages.push(image);
             }
@@ -102,9 +109,6 @@ export const InitialsImages = {
         },
         onLoaded(group) {
             this.$set(this.loaded, group, true);
-        },
-        __getContext(initials, engraving, group) {
-            return [`step::personalization:${group}`, "step::personalization"];
         }
     }
 };

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -47,6 +47,10 @@ export const InitialsImages = {
         initialsBuilder: {
             type: Function,
             default: null
+        },
+        contextGetter: {
+            type: Function,
+            default: null
         }
     },
     data: function() {
@@ -82,7 +86,8 @@ export const InitialsImages = {
                 const image = this.$ripe.bindImage(initialsImage, {
                     showInitials: true,
                     initialsGroup: initialsImage.dataset.group,
-                    initialsBuilder: this.initialsBuilder
+                    baseInitialsBuilder: this.initialsBuilder,
+                    context: this.contextGetter || this.__getContext
                 });
                 this.initialsImages.push(image);
             }
@@ -97,6 +102,9 @@ export const InitialsImages = {
         },
         onLoaded(group) {
             this.$set(this.loaded, group, true);
+        },
+        __getContext(group) {
+            return [`step::personalization:${group}`, "step::personalization"];
         }
     }
 };

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -67,7 +67,6 @@ export const InitialsImages = {
         context(value) {
             if (!value.length) return;
             for (const image of this.initialsImages) {
-                console.log(image);
                 image.setContext(value);
             }
         }

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -103,7 +103,7 @@ export const InitialsImages = {
         onLoaded(group) {
             this.$set(this.loaded, group, true);
         },
-        __getContext(group) {
+        __getContext(initials, engraving, group) {
             return [`step::personalization:${group}`, "step::personalization"];
         }
     }

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -310,7 +310,7 @@ export const Reference = {
                 profile: profiles
             };
         },
-        __getContext(group) {
+        __getContext(engraving, group) {
             const position = this.propertiesData[group] && this.propertiesData[group].position;
             const contexts = [`step::personalization:${group}`, "step::personalization"];
             if (!position) return contexts;

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -5,7 +5,7 @@
             v-bind:model="model"
             v-bind:groups="groups"
             v-bind:initials-builder="__initialsBuilder"
-            v-bind:context-getter="__getContext"
+            v-bind:context="context"
         />
         <div class="form">
             <div class="form-group" v-for="group in groups" v-bind:key="group">
@@ -123,7 +123,8 @@ export const Reference = {
              */
             propertiesData: {},
             initialsText: {},
-            groups: []
+            groups: [],
+            context: []
         };
     },
     computed: {
@@ -281,6 +282,10 @@ export const Reference = {
             if (!newProperties[group]) newProperties[group] = {};
             newProperties[group][type] = value;
             this.propertiesData = newProperties;
+
+            // updates the context based on the new properties selected,
+            // more specifically the position property
+            this.context = this.__getContext(group);
         },
         /**
          * "Generic" initials builder function that uses the current properties
@@ -315,15 +320,12 @@ export const Reference = {
             };
         },
         /**
-         * "Generic" context builder function that returns the context for te initials
+         * "Generic" context function that returns the context for the initials
          * based on the position in the current properties and the current group.
          *
-         * @param {String} initials The value of the initials to compute the computed
-         * initials object.
-         * @param {String} engraving The value of the engraving of the current personalization.
          * @param {String} group The value of the initials group.
          */
-        __getContext(initials, engraving, group) {
+        __getContext(group) {
             const position = this.propertiesData[group] && this.propertiesData[group].position;
             const contexts = [`step::personalization:${group}`, "step::personalization"];
             if (!position) return contexts;

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -286,20 +286,24 @@ export const Reference = {
          * "Generic" initials builder function that uses the current properties
          * context to build a series of extra profiles.
          *
-         * This function is compliant with the expected initials builder interface.
+         * This function is compliant with the expected base initials builder interface.
          *
          * @param {String} initials The value of the initials to compute the computed
          * initials object.
          * @param {String} engraving The value of the engraving to compute the computed
          * initials object.
-         * @param {Object} properties The initials properties of the build.
-         * @param {String} group The value of the initials group.
+         * @param {Element} element The DOM element to be used in the "calculus" of the
+         * final initials object.
          * @returns {Object} The computed initials object containing both the final
          * initials string value and profile(s) sequence.
          */
         __initialsBuilder(initials, engraving, element) {
+            // uses the provided element to obtain the selected group and obtains the
+            // "base" personalization profiles for such group
             const group = element.getAttribute("data-group");
 
+            // iterates over each of the properties for the group and builds the base
+            // profiles with the property value and type and only with the group
             const profiles = [{ type: group, name: group }];
             Object.entries(this.propertiesData[group]).forEach(([type, value]) => {
                 profiles.push({ type: type, name: value });
@@ -310,6 +314,13 @@ export const Reference = {
                 profile: profiles
             };
         },
+        /**
+         * "Generic" context builder function that returns the context for te initials
+         * based on the position in the current properties and the current group.
+         *
+         * @param {String} engraving The value of the engraving of the current personalization.
+         * @param {String} group The value of the initials group.
+         */
         __getContext(engraving, group) {
             const position = this.propertiesData[group] && this.propertiesData[group].position;
             const contexts = [`step::personalization:${group}`, "step::personalization"];

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -304,7 +304,7 @@ export const Reference = {
 
             // iterates over each of the properties for the group and builds the base
             // profiles with the property value and type and only with the group
-            const profiles = [{ type: group, name: group }];
+            const profiles = [{ type: "group", name: group }];
             Object.entries(this.propertiesData[group]).forEach(([type, value]) => {
                 profiles.push({ type: type, name: value });
             });
@@ -318,10 +318,12 @@ export const Reference = {
          * "Generic" context builder function that returns the context for te initials
          * based on the position in the current properties and the current group.
          *
+         * @param {String} initials The value of the initials to compute the computed
+         * initials object.
          * @param {String} engraving The value of the engraving of the current personalization.
          * @param {String} group The value of the initials group.
          */
-        __getContext(engraving, group) {
+        __getContext(initials, engraving, group) {
             const position = this.propertiesData[group] && this.propertiesData[group].position;
             const contexts = [`step::personalization:${group}`, "step::personalization"];
             if (!position) return contexts;

--- a/vue/components/molecules/thumbnails-groups/thumbnails-groups.vue
+++ b/vue/components/molecules/thumbnails-groups/thumbnails-groups.vue
@@ -6,6 +6,7 @@
         v-bind:active-group="activeGroup"
         v-bind:groups="groups"
         v-bind:initials-builder="__initialsBuilder"
+        v-bind:context-getter="__getContext"
         ref="thumbnailsContainer"
         v-on:image-selected="onImageSelected"
     />

--- a/vue/components/molecules/thumbnails-groups/thumbnails-groups.vue
+++ b/vue/components/molecules/thumbnails-groups/thumbnails-groups.vue
@@ -6,7 +6,7 @@
         v-bind:active-group="activeGroup"
         v-bind:groups="groups"
         v-bind:initials-builder="__initialsBuilder"
-        v-bind:context-getter="__getContext"
+        v-bind:context="context"
         ref="thumbnailsContainer"
         v-on:image-selected="onImageSelected"
     />
@@ -45,7 +45,8 @@ export const ThumbnailsGroups = {
     },
     data: function() {
         return {
-            activeGroupData: this.activeGroup
+            activeGroupData: this.activeGroup,
+            context: []
         };
     },
     computed: {
@@ -57,6 +58,9 @@ export const ThumbnailsGroups = {
         },
         configInitials() {
             return this.$store.state.config.initials;
+        },
+        engraving() {
+            return this.$store.state.personalization.engraving;
         }
     },
     watch: {
@@ -66,6 +70,9 @@ export const ThumbnailsGroups = {
         activeGroupData(value) {
             this.$emit("update:active-group", value);
         }
+    },
+    mounted: function() {
+        this.context = this.__getContext(this.engraving, this.activeGroupData);
     },
     methods: {
         onImageSelected(group) {

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -173,20 +173,17 @@ export const logicMixin = {
             };
         },
         /**
-         * "Generic" context builder function that returns the context for te initials
+         * "Generic" context function that returns the context for the initials
          * based on the position in the current properties and the current group.
          *
-         * @param {String} initials The string that contains the initials that are
-         * going to be used in the building process.
          * @param {String} engraving The value of the engraving of the current personalization.
          * @param {String} group The value of the initials group.
          */
-        __getContext(initials, engraving, group) {
+        __getContext(engraving, group) {
             const properties = engraving
                 ? this.$ripe.parseEngraving(engraving, this.config.initials.properties).valuesM
                 : {};
             const position = properties.position;
-
             const contexts = [`step::personalization:${group}`, "step::personalization"];
             if (!position) return contexts;
 

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -176,10 +176,12 @@ export const logicMixin = {
          * "Generic" context builder function that returns the context for te initials
          * based on the position in the current properties and the current group.
          *
+         * @param {String} initials The string that contains the initials that are
+         * going to be used in the building process.
          * @param {String} engraving The value of the engraving of the current personalization.
          * @param {String} group The value of the initials group.
          */
-        __getContext(engraving, group) {
+        __getContext(initials, engraving, group) {
             const properties = engraving
                 ? this.$ripe.parseEngraving(engraving, this.config.initials.properties).valuesM
                 : {};

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -172,6 +172,13 @@ export const logicMixin = {
                 profile: profiles
             };
         },
+        /**
+         * "Generic" context builder function that returns the context for te initials
+         * based on the position in the current properties and the current group.
+         *
+         * @param {String} engraving The value of the engraving of the current personalization.
+         * @param {String} group The value of the initials group.
+         */
         __getContext(engraving, group) {
             const properties = engraving
                 ? this.$ripe.parseEngraving(engraving, this.config.initials.properties).valuesM

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -158,49 +158,34 @@ export const logicMixin = {
             const properties = engraving
                 ? this.$ripe.parseEngraving(engraving, this.config.initials.properties).valuesM
                 : {};
-            const profiles = this.__buildPersonalizationProfiles(group, properties);
+            const profiles = [{ type: group, name: group }];
 
             // iterates over each of the properties for the groups and builds the base
             // profiles with the property value with the group suffix and the basic
             // profile with "just" the property value
             Object.entries(properties).forEach(([type, value]) => {
-                this.initialsGroups.length > 1 && profiles.push(value + ":" + group);
-                profiles.push(value);
+                profiles.push({ type: type, name: value });
             });
-
-            profiles.push(group);
 
             return {
                 initials: initials || "$empty",
                 profile: profiles
             };
         },
-        /**
-         * Builds a series of "personalization oriented" profiles taking
-         * into account a series of pre-defined heuristics that should be
-         * applicable to most initials contexts and structures.
-         *
-         * These profiles are applicable under a series of best practices
-         * and may not provide optimal results.
-         *
-         * @param {String} group The name of the group to obtain the profiles.
-         * @param {Object} properties The properties object that should be
-         * used as the basis for the building of the profiles.
-         */
-        __buildPersonalizationProfiles(group, properties) {
-            const alias = this.config.initials.$alias;
-            if (!alias) return [];
-
+        __getContext(engraving, group) {
+            const properties = engraving
+                ? this.$ripe.parseEngraving(engraving, this.config.initials.properties).valuesM
+                : {};
             const position = properties.position;
 
-            return []
-                .concat(
-                    position && group ? alias[`step::personalization:${position}:${group}`] : [],
-                    position ? alias[`step::personalization:${position}`] : [],
-                    group ? alias[`step::personalization:${group}`] : [],
-                    alias["step::personalization"]
-                )
-                .filter(v => v !== undefined);
+            const contexts = [`step::personalization:${group}`, "step::personalization"];
+            if (!position) return contexts;
+
+            return [
+                `step::personalization:${position}:${group}`,
+                `step::personalization:${position}`,
+                ...contexts
+            ];
         }
     }
 };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-compose/issues/84 |
| Dependencies | https://github.com/ripe-tech/ripe-sdk/pull/206 |
| Decisions | • Already existing initials builder is given to the `initials-images` component to allow reactivity when changing the dropdowns, it will be served to the `sdk` as `baseInitialsBuilder`. <br> • Function that returns context was defined to return `personalization` context based on the `group` and current `position` and is sent to the `initials-images`. |
| Animated GIF | ![Oct-15-2020 17-09-07](https://user-images.githubusercontent.com/25725586/96156735-53cd0700-0f09-11eb-9358-0c92247d59c6.gif)<br>Configuration example in the build: <br><img width="600" alt="Screenshot 2020-10-21 at 09 03 41" src="https://user-images.githubusercontent.com/25725586/96691699-1e973d80-137d-11eb-9a5f-3e3beee058ce.png">|
