### PR TITLE
Remove .text() from runLogicP call

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -286,10 +286,9 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
             const [groups, supportedCharacters] = await Promise.all([
                 this.ripe.runLogicP({ method: "groups" }),
                 (async () => {
-                    const supportedCharactersBlob = await this.ripe.runLogicP({
+                    const supportedCharacters = await this.ripe.runLogicP({
                         method: "supported_characters"
                     });
-                    const supportedCharacters = await supportedCharactersBlob.text();
                     return [...supportedCharacters];
                 })()
             ]);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to https://github.com/ripe-tech/ripe-sdk/pull/205 |
| Dependencies | -- |
| Decisions | Removed `.text()` from `runLogicP` call since that conversion is made by the `sdk`.  |
| Animated GIF | -- |
