### PR TITLE
#641 Add fix for initials_extra event not updating initials and engraving

### DIFF
--- a/js/util/index.js
+++ b/js/util/index.js
@@ -1,4 +1,5 @@
 export * from "./data";
 export * from "./device";
 export * from "./logging";
+export * from "./ripe";
 export * from "./url-changer";

--- a/js/util/ripe.js
+++ b/js/util/ripe.js
@@ -1,0 +1,14 @@
+export const initialsFromExtra = function(initialsExtra, initials, engraving) {
+    initialsExtra = initialsExtra || {};
+    const groups = Object.keys(initialsExtra);
+    const mainGroup = groups.includes("main") || groups.length === 0 ? "main" : groups[0];
+    const mainInitials = initialsExtra[mainGroup] || {};
+
+    initials = initials === undefined ? mainInitials.initials : initials;
+    engraving = engraving === undefined ? mainInitials.engraving : engraving;
+
+    return {
+        initials: initials || "",
+        engraving: engraving || null
+    };
+};

--- a/vue/components/organisms/personalization/personalization.vue
+++ b/vue/components/organisms/personalization/personalization.vue
@@ -303,20 +303,11 @@ export const Personalization = {
 
         this.$bus.bind("initials_extra", initialsExtra => {
             if (this.diffInitialsExtra(initialsExtra, this.state.initialsExtra)) {
-                const groups = Object.keys(initialsExtra);
-                const isEmpty = groups.length === 0;
-                const mainGroup = groups.includes("main") ? "main" : groups[0];
-                const mainInitials = initialsExtra[mainGroup];
+                const { initials, engraving } = this.initialsFromExtra(initialsExtra);
 
-                if (isEmpty) {
-                    this.state.initials = "";
-                    this.state.engraving = null;
-                    this.state.initialsExtra = {};
-                } else {
-                    this.state.initials = mainInitials.initials || "";
-                    this.state.engraving = mainInitials.engraving || null;
-                    this.state.initialsExtra = initialsExtra;
-                }
+                this.state.initials = initials;
+                this.state.engraving = engraving;
+                this.state.initialsExtra = initialsExtra;
                 if (this.$refs.form) this.$refs.form.setState(this.state);
             }
         });

--- a/vue/components/organisms/personalization/personalization.vue
+++ b/vue/components/organisms/personalization/personalization.vue
@@ -248,7 +248,20 @@ export const Personalization = {
 
         this.$bus.bind("initials_extra", initialsExtra => {
             if (this.diffInitialsExtra(initialsExtra, this.state.initialsExtra)) {
-                this.state.initialsExtra = initialsExtra;
+                const groups = Object.keys(initialsExtra);
+                const isEmpty = groups.length === 0;
+                const mainGroup = groups.includes("main") ? "main" : groups[0];
+                const mainInitials = initialsExtra[mainGroup];
+
+                if (isEmpty) {
+                    this.state.initials = "";
+                    this.state.engraving = null;
+                    this.state.initialsExtra = {};
+                } else {
+                    this.state.initials = mainInitials.initials || "";
+                    this.state.engraving = mainInitials.engraving || null;
+                    this.state.initialsExtra = initialsExtra;
+                }
                 if (this.$refs.form) this.$refs.form.setState(this.state);
             }
         });

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -1,3 +1,5 @@
+import { initialsFromExtra } from "../../js/util";
+
 export const logicMixin = {
     inject: {
         manager: {
@@ -68,6 +70,9 @@ export const logicMixin = {
         this.$bus.bind("refresh", this.$forceUpdate);
     },
     methods: {
+        initialsFromExtra(initialsExtra, initials, engraving) {
+            return initialsFromExtra(initialsExtra, initials, engraving);
+        },
         /**
          * Checks if two 'initialsExtra' are equal, by using a deep
          * comparison analysis. Equality is defined as, they produce

--- a/vue/store.js
+++ b/vue/store.js
@@ -1,3 +1,5 @@
+import { initialsFromExtra } from "../js/util";
+
 export const store = {
     state: {
         ripe_url: "",
@@ -95,16 +97,14 @@ export const store = {
             state.price = price;
         },
         personalization(state, value) {
-            const groups = Object.keys(value);
-            const mainGroup = groups.includes("main") ? "main" : groups[0];
-            const mainInitials = value[mainGroup] || {};
+            const { initials, engraving } = initialsFromExtra(
+                value.initialsExtra,
+                value.initials,
+                value.engraving
+            );
 
-            const initials = value.initials === undefined ? mainInitials.initials : value.initials;
-            const engraving =
-                value.engraving === undefined ? mainInitials.engraving : value.engraving;
-
-            state.personalization.initials = initials || "";
-            state.personalization.engraving = engraving || null;
+            state.personalization.initials = initials;
+            state.personalization.engraving = engraving;
             state.personalization.initialsExtra = Object.assign({}, value.initialsExtra);
         },
         size(state, value) {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/641 |
| Decisions | Set legacy initials and engraving when `initials_extra` changes in `<personalization>` of ripe-commons-pluginus. The methodology is the same as in [ripe-sdk](https://github.com/ripe-tech/ripe-sdk/blob/088f6c6f4c6e0b8b4228088b67a6405cb0d9484a/src/js/base/ripe.js#L740). |
| Animated GIF | ![Peek 2020-11-12 11-39](https://user-images.githubusercontent.com/24736423/98936234-9835cd80-24dc-11eb-82d9-479615af16c0.gif) |


