### PR TITLE
#644 Add missing tab properties

### DIFF
--- a/bundles/config.en_us.json
+++ b/bundles/config.en_us.json
@@ -6,6 +6,19 @@
     "ripe_commons.modal.apply": "Apply",
     "ripe_commons.modal.select": "Select",
 
+    "ripe_commons.group.main": "Main",
+    "ripe_commons.group.left": "Left",
+    "ripe_commons.group.right": "Right",
+    "ripe_commons.group.front": "Front",
+    "ripe_commons.group.back": "Back",
+    "ripe_commons.group.side": "Side",
+
+    "ripe_commons.properties.font": "Font",
+    "ripe_commons.properties.font_size": "Font Size",
+    "ripe_commons.properties.style": "Style",
+    "ripe_commons.properties.position": "Position",
+    "ripe_commons.properties.color": "Color",
+
     "ripe_commons.restrictions_alert.restrictions_alert": "Undo",
     "ripe_commons.restrictions_alert.back_button": "Back",
     "ripe_commons.restrictions_alert.close_button": "Close",

--- a/bundles/config.ja_jp.json
+++ b/bundles/config.ja_jp.json
@@ -6,6 +6,19 @@
     "ripe_commons.modal.apply": "申し込み",
     "ripe_commons.modal.select": "申し込み",
 
+    "ripe_commons.group.main": "メイン",
+    "ripe_commons.group.left": "左",
+    "ripe_commons.group.right": "正しい",
+    "ripe_commons.group.front": "前面",
+    "ripe_commons.group.back": "バック",
+    "ripe_commons.group.side": "側",
+
+    "ripe_commons.properties.font": "フォント",
+    "ripe_commons.properties.font_size": "フォントサイズ",
+    "ripe_commons.properties.style": "スタイル",
+    "ripe_commons.properties.position": "位置",
+    "ripe_commons.properties.color": "色",
+
     "ripe_commons.restrictions_alert.restrictions_alert": "元に戻る",
     "ripe_commons.restrictions_alert.back_button": "バック",
     "ripe_commons.restrictions_alert.close_button": "閉じる",
@@ -14,6 +27,12 @@
 
     "ripe_commons.personalization.personalization": "パーソナライゼーション",
     "ripe_commons.personalization.add_initials": "イニシャルを追加",
+    "ripe_commons.personalization.group": "グループ",
+    "ripe_commons.personalization.initials": "イニシャル",
+    "ripe_commons.personalization.select.style": "スタイルを選択",
+    "ripe_commons.personalization.select.font": "フォントを選択してください",
+    "ripe_commons.personalization.select.position": "位置を選択してください",
+    "ripe_commons.personalization.select.color": "色を選択してください",
 
     "ripe_commons.size.size": "サイズ",
     "ripe_commons.size.select_size": "サイズ",

--- a/bundles/config.zh_cn.json
+++ b/bundles/config.zh_cn.json
@@ -6,6 +6,19 @@
     "ripe_commons.modal.apply": "采用",
     "ripe_commons.modal.select": "采用",
 
+    "ripe_commons.group.main": "主要",
+    "ripe_commons.group.left": "左",
+    "ripe_commons.group.right": "右",
+    "ripe_commons.group.front": "面前",
+    "ripe_commons.group.back": "背部",
+    "ripe_commons.group.side": "侧",
+
+    "ripe_commons.properties.font": "字体",
+    "ripe_commons.properties.font_size": "字体大小",
+    "ripe_commons.properties.style": "样式",
+    "ripe_commons.properties.position": "位置",
+    "ripe_commons.properties.color": "颜色",
+
     "ripe_commons.restrictions_alert.restrictions_alert": "复原",
     "ripe_commons.restrictions_alert.back_button": "背部",
     "ripe_commons.restrictions_alert.close_button": "关",
@@ -14,6 +27,12 @@
 
     "ripe_commons.personalization.personalization": "个性化定制",
     "ripe_commons.personalization.add_initials": "专属刻字",
+    "ripe_commons.personalization.group": "组",
+    "ripe_commons.personalization.initials": "首字母",
+    "ripe_commons.personalization.select.style": "选择样式",
+    "ripe_commons.personalization.select.font": "选择字体",
+    "ripe_commons.personalization.select.position": "选择职位",
+    "ripe_commons.personalization.select.color": "选择颜色",
 
     "ripe_commons.size.size": "尺码",
     "ripe_commons.size.select_size": "尺码",

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -9,29 +9,32 @@
         <div class="form">
             <div class="form-group" v-for="group in groups" v-bind:key="group">
                 <p class="subtitle">
-                    {{ locale("ripe_commons.personalization.group") }} {{ group }}
+                    {{ locale("ripe_commons.personalization.group") }}
+                    {{ locale(`ripe_commons.group.${group}`, readable(capitalize(group))) }}
                 </p>
                 <form-input
-                    v-bind:header="(`properties.${type}`, readable(capitalize(type))) | locale"
+                    v-bind:header="
+                        locale(`ripe_commons.properties.${type}`, readable(capitalize(type)))
+                    "
                     v-bind:header-size="'large'"
                     v-for="[type, options] in Object.entries(properties())"
                     v-bind:key="type"
                 >
                     <select-ripe
                         v-bind:class="`select-${type}`"
-                        v-bind:placeholder="`ripe_commons.personalization.select.${type}` | locale"
+                        v-bind:placeholder="locale(`ripe_commons.personalization.select.${type}`)"
                         v-bind:options="options"
                         v-bind:value="propertiesData[group][type]"
                         v-on:update:value="value => onValueUpdate(value, group, type)"
                     />
                 </form-input>
                 <form-input
-                    v-bind:header="'ripe_commons.personalization.initials' | locale"
+                    v-bind:header="locale('ripe_commons.personalization.initials')"
                     v-bind:header-size="'large'"
                 >
                     <input-ripe
                         class="input-initials"
-                        v-bind:placeholder="'ripe_commons.personalization.add_initials' | locale"
+                        v-bind:placeholder="locale('ripe_commons.personalization.add_initials')"
                         v-bind:value.sync="initialsText[group]"
                     />
                 </form-input>

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -211,6 +211,8 @@ export const Reference = {
                     this.tabProperties.forEach(propertyName => {
                         const property = this.propertiesData[group][propertyName];
                         if (!property) return;
+                        const availableProperties = this.properties()[propertyName] || [];
+                        if (availableProperties.length < 2) return;
 
                         text.push(
                             this.locale(

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -111,7 +111,7 @@ export const Reference = {
          */
         tabProperties: {
             type: Array,
-            default: () => ["font", "style"]
+            default: () => ["font", "font_size", "style", "position", "color"]
         }
     },
     data: function() {

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -211,6 +211,9 @@ export const Reference = {
                     this.tabProperties.forEach(propertyName => {
                         const property = this.propertiesData[group][propertyName];
                         if (!property) return;
+
+                        // if there is only one single option,
+                        // then don't include it in the tab message
                         const availableProperties = this.properties()[propertyName] || [];
                         if (availableProperties.length < 2) return;
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/664 |
| Decisions | Add missing tab properties to appear on tab message. Those will be matched with chosen model properties and translated accordingly if they exist, otherwise. |
| Animated GIF | Below |

## Before
![image](https://user-images.githubusercontent.com/24736423/99081944-6f383a00-25bb-11eb-8acb-dce398ba4e68.png)

## After
![image](https://user-images.githubusercontent.com/24736423/99081876-54fe5c00-25bb-11eb-84f3-8ef106b9003e.png)

