### PR TITLE
Object.assign before saving to store

### DIFF
--- a/vue/store.js
+++ b/vue/store.js
@@ -105,7 +105,7 @@ export const store = {
 
             state.personalization.initials = initials || "";
             state.personalization.engraving = engraving || null;
-            state.personalization.initialsExtra = value.initialsExtra;
+            state.personalization.initialsExtra = Object.assign({}, value.initialsExtra);
         },
         size(state, value) {
             state.size = value;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Detected when working in https://github.com/ripe-tech/ripe-retail-vendors/pull/72, where the lack of it would lead to weird behavior because of a shared variable between unrelated components. |
