### PR TITLE
Fix personalization modal properties locale reactivity

### DIFF
--- a/js/locale/locale.js
+++ b/js/locale/locale.js
@@ -65,16 +65,18 @@ export class LocalePlugin extends RipeCommonsPlugin {
         this.owner.trigger("locale_changed", locale);
     }
 
-    setLocaleValue(key, value, locale) {
+    setLocaleValue(key, value, locale, options = { event: true }) {
         const localeKeys = this.localeMap[locale] || {};
         localeKeys[key] = value;
         this.localeMap[locale] = localeKeys;
         this.owner.trigger("locale", key, value, locale);
+        if (options.event) this.owner.trigger("locale_map_changed");
     }
 
-    unsetLocaleValue(key, locale) {
+    unsetLocaleValue(key, locale, options = { event: true }) {
         const localeKeys = this.localeMap[locale] || {};
         delete localeKeys[key];
+        if (options.event) this.owner.trigger("locale_map_changed");
     }
 
     setLocaleMap(localeMap, prefix = "") {
@@ -82,7 +84,7 @@ export class LocalePlugin extends RipeCommonsPlugin {
         for (const locale in localeMap) {
             const bundle = localeMap[locale];
             for (const key in bundle) {
-                this.setLocaleValue(`${prefix}${key}`, bundle[key], locale);
+                this.setLocaleValue(`${prefix}${key}`, bundle[key], locale, { event: false });
             }
         }
         this.owner.trigger("locale_map_changed");
@@ -93,7 +95,7 @@ export class LocalePlugin extends RipeCommonsPlugin {
         for (const locale in localeMap) {
             const bundle = localeMap[locale];
             for (const key in bundle) {
-                this.unsetLocaleValue(`${prefix}.${key}`, locale);
+                this.unsetLocaleValue(`${prefix}.${key}`, locale, { event: false });
             }
         }
         this.owner.trigger("locale_map_changed");

--- a/js/locale/model-locale-loader.js
+++ b/js/locale/model-locale-loader.js
@@ -39,7 +39,7 @@ export class ModelLocaleLoaderPlugin extends RipeCommonsPlugin {
             const bundle = ripeProvider.ripe.getBundle(locale);
             for (const [key, value] of Object.entries(bundle)) {
                 if (key === "_" && value === null) continue;
-                localePlugin.setLocaleValue(key, value, locale);
+                localePlugin.setLocaleValue(key, value, locale, { event: false });
             }
         }
         this.owner.trigger("locale_map_changed");
@@ -74,7 +74,7 @@ export class ModelLocaleLoaderPlugin extends RipeCommonsPlugin {
 
         for (const key in result) {
             if (key === "_" && result[key] === null) continue;
-            localePlugin.setLocaleValue(key, result[key], currentLocale);
+            localePlugin.setLocaleValue(key, result[key], currentLocale, { event: false });
         }
     }
 }

--- a/js/locale/model-locale-loader.js
+++ b/js/locale/model-locale-loader.js
@@ -27,7 +27,6 @@ export class ModelLocaleLoaderPlugin extends RipeCommonsPlugin {
         for (const locale of new Set(locales)) {
             await this._loadModelLocale(brand, model, locale);
         }
-        this.owner.trigger("locale_map_changed");
     }
 
     async loadRipeSdkLocales() {
@@ -76,6 +75,7 @@ export class ModelLocaleLoaderPlugin extends RipeCommonsPlugin {
             if (key === "_" && result[key] === null) continue;
             localePlugin.setLocaleValue(key, result[key], currentLocale, { event: false });
         }
+        this.owner.trigger("locale_map_changed");
     }
 }
 

--- a/js/locale/model-locale-loader.js
+++ b/js/locale/model-locale-loader.js
@@ -27,6 +27,7 @@ export class ModelLocaleLoaderPlugin extends RipeCommonsPlugin {
         for (const locale of new Set(locales)) {
             await this._loadModelLocale(brand, model, locale);
         }
+        this.owner.trigger("locale_map_changed");
     }
 
     async loadRipeSdkLocales() {
@@ -41,6 +42,7 @@ export class ModelLocaleLoaderPlugin extends RipeCommonsPlugin {
                 localePlugin.setLocaleValue(key, value, locale);
             }
         }
+        this.owner.trigger("locale_map_changed");
     }
 
     _bind() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | If we open a shoe with locale set to `en_us` then change that locale to `ja_jp` in white technical settings, the personlization modal will not update it's property options. See GIF below |
| Decisions | `locale_map_changed` needs to be triggered every time `localeMap` suffers mutations. Add triggers after calling `loadModelLocales` and  `loadRipeSdkLocales`.  |
| Animated GIF | Below |

### Before
![Peek 2020-11-19 18-13](https://user-images.githubusercontent.com/24736423/99706802-854e6a80-2a93-11eb-8fc1-f46531213c3c.gif)

### After
![Peek 2020-11-19 18-14](https://user-images.githubusercontent.com/24736423/99706807-87b0c480-2a93-11eb-80f4-1bf9b10f2583.gif)
