### PR TITLE
#685 Fix scale labels not being localized

### DIFF
--- a/vue/components/forms/size-form/reference.vue
+++ b/vue/components/forms/size-form/reference.vue
@@ -26,7 +26,7 @@
                         v-bind:key="modelScale"
                         v-on:click="scale = modelScale"
                     >
-                        {{ locale(modelScale) }}
+                        {{ $ripe.localeLocal(`scales.${modelScale}`) }}
                     </div>
                 </div>
                 <div


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/685 |
| Decisions | Fix localization of scales by localizing them from ripe sdk `Ripe.localeLocal()` method instead of `locale()` which doesn't have the needed scale locales in `LocalePlugin.localeMap`. |
| Animated GIF | ![image](https://user-images.githubusercontent.com/24736423/99824414-98be0c00-2b4d-11eb-8076-5dd3103211c4.png) |
