### PR TITLE
refreshInitialsData only when needed

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -342,9 +342,8 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
             this.store.commit("hasPersonalization", this.ripe.hasPersonalization());
             this.store.commit("hasSize", this.ripe.hasSize());
 
-            // clear the initials information, as it is possibly outdated
-            this.store.commit("initialsGroups", null);
-            this.store.commit("initialsSupportedCharacters", null);
+            // clear the initials data, as it is possibly outdated
+            this.store.commit("clearInitialsData");
         });
 
         // changes some internal structure whenever there's an update

--- a/js/base/main.js
+++ b/js/base/main.js
@@ -282,39 +282,6 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
         };
     }
 
-    /**
-     * Runs the remote operation that refreshes both the groups
-     * and the supported characters for the initials of the current
-     * configuration in context.
-     */
-    async refreshInitialsData() {
-        try {
-            // runs the remote business logic to obtain the multiple
-            // target groups available for initials as well as the
-            // available characters for personalization
-            const [groups, supportedCharacters] = await Promise.all([
-                this.ripe.runLogicP({ method: "groups" }),
-                (async () => {
-                    const supportedCharacters = await this.ripe.runLogicP({
-                        method: "supported_characters"
-                    });
-                    return [...supportedCharacters];
-                })()
-            ]);
-
-            // updates the store with both the groups and the supported
-            // characters of the current configuration context
-            this.store.commit("initialsGroups", groups);
-            this.store.commit("initialsSupportedCharacters", supportedCharacters);
-        } catch (err) {
-            // gives a default group if builds does not support remote
-            // business logic (for the `groups` and `supported_characters`
-            // "methods")
-            this.store.commit("initialsGroups", ["main"]);
-            this.store.commit("initialsSupportedCharacters", ["abcdefghijklmnopqrstvwxyz"]);
-        }
-    }
-
     _bind() {
         // listens for the 'set_model' event to change the
         // model accordingly
@@ -375,9 +342,9 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
             this.store.commit("hasPersonalization", this.ripe.hasPersonalization());
             this.store.commit("hasSize", this.ripe.hasSize());
 
-            // runs the refresh operation on the initials information
-            // this operation is going to trigger remote logic execution
-            await this.refreshInitialsData();
+            // clear the initials information, as it is possibly outdated
+            this.store.commit("initialsGroups", null);
+            this.store.commit("initialsSupportedCharacters", null);
         });
 
         // changes some internal structure whenever there's an update

--- a/vue/store.js
+++ b/vue/store.js
@@ -34,9 +34,9 @@ export const store = {
         hasSize: false,
         ripeOptions: {},
         ripeState: {},
-        initialsDataPromise: null,
         initialsGroups: null,
-        initialsSupportedCharacters: null
+        initialsSupportedCharacters: null,
+        initialsDataPromise: null
     },
     mutations: {
         ripeUrl(state, url) {
@@ -144,27 +144,29 @@ export const store = {
         ripeState(state, ripeState) {
             state.ripeState = ripeState;
         },
-        initialsDataPromise(state, initialsDataPromise) {
-            state.initialsDataPromise = initialsDataPromise;
-        },
-        clearInitialsData(state) {
-            state.initialsGroups = null;
-            state.initialsSupportedCharacters = null;
-        },
         initialsGroups(state, initialsGroups) {
             state.initialsGroups = initialsGroups;
         },
         initialsSupportedCharacters(state, initialsSupportedCharacters) {
             state.initialsSupportedCharacters = initialsSupportedCharacters;
+        },
+        clearInitialsData(state) {
+            state.initialsGroups = null;
+            state.initialsSupportedCharacters = null;
+        },
+        initialsDataPromise(state, initialsDataPromise) {
+            state.initialsDataPromise = initialsDataPromise;
         }
     },
     actions: {
-        async getInitialsData({ state, commit }) {
-            // in case a request is already ongoing just reuse it
+        async refreshInitialsData({ state, commit }, force = false) {
+            // in case a request is already ongoing just reuse it, this avoids
+            // parallel duplicated requests (race and performance issues)
             if (state.initialsDataPromise) return state.initialsDataPromise;
 
-            // if the data was already fetched there is nothing to do
-            if (state.initialsGroups && state.initialsSupportedCharacters) return;
+            // if the data was already fetched there is nothing to do, we
+            // assume that further requests would be redundant
+            if (state.initialsGroups && state.initialsSupportedCharacters && !force) return;
 
             // runs the remote business logic to obtain the multiple
             // target groups available for initials as well as the
@@ -179,21 +181,26 @@ export const store = {
                 })()
             ]);
 
-            // store the ongoing request so we
-            // avoid redundant requests
+            // stores the ongoing request so we avoid future redundant requests
+            // this is critical due to performance reasons
             commit("initialsDataPromise", promise);
 
             try {
+                // obtains the remote data and updates the local store information
+                // to reflect the remote information
                 const [groups, supportedCharacters] = await promise;
                 commit("initialsGroups", groups);
                 commit("initialsSupportedCharacters", supportedCharacters);
             } catch (err) {
                 // gives a default group if builds does not support remote
                 // business logic (for the `groups` and `supported_characters`
-                // "methods")
+                // "methods"), this is a naive implementation for the scenarios
+                // where no server side logic exists for initials (supported_characters)
                 commit("initialsGroups", "main");
                 commit("initialsSupportedCharacters", ["abcdefghijklmnopqrstvwxyz"]);
             } finally {
+                // releases the "lock" controlled by the initials data promise, so that
+                // future remote requests can go on
                 commit("initialsDataPromise", null);
             }
         }

--- a/vue/store.js
+++ b/vue/store.js
@@ -147,6 +147,10 @@ export const store = {
         initialsDataPromise(state, initialsDataPromise) {
             state.initialsDataPromise = initialsDataPromise;
         },
+        clearInitialsData(state) {
+            state.initialsGroups = null;
+            state.initialsSupportedCharacters = null;
+        },
         initialsGroups(state, initialsGroups) {
             state.initialsGroups = initialsGroups;
         },
@@ -155,13 +159,11 @@ export const store = {
         }
     },
     actions: {
-        async getPersonalizationInfo({ state, commit }) {
-            // in case a request is already ongoing
-            // just reuse it
+        async getInitialsData({ state, commit }) {
+            // in case a request is already ongoing just reuse it
             if (state.initialsDataPromise) return state.initialsDataPromise;
 
-            // if the data was already fetched
-            // there is nothing to do
+            // if the data was already fetched there is nothing to do
             if (state.initialsGroups && state.initialsSupportedCharacters) return;
 
             // runs the remote business logic to obtain the multiple


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-commons-pluginus/pull/175#pullrequestreview-532307550 |
| Decisions | Do it only when the model has personalization. Allows being called from any point in the application but currently, that's not needed. |

