### PR TITLE
#673: Centering scroll logic applied to parts+materials

### DIFF
--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -463,6 +463,14 @@ export const Pickers = {
             type: Boolean,
             default: false
         },
+        enableCenterParts: {
+            type: Boolean,
+            default: false
+        },
+        enableCenterMaterials: {
+            type: Boolean,
+            default: false
+        },
         beforeButtonsParts: {
             type: Array,
             default: () => []
@@ -708,29 +716,6 @@ export const Pickers = {
             const colors = colorsPicker.querySelectorAll(".button-color-option");
             this.slideRight(colorsPicker, colors);
         },
-        centerElement(elementsContainer, elements, valueLabel, expectedValue) {
-            let scroll = 0;
-            for (const _element of elements) {
-                const style = getComputedStyle(_element);
-                const marginLeft = parseFloat(style.marginLeft);
-                const marginRight = parseFloat(style.marginRight);
-
-                // centers the selected element in the middle of the container
-                if (_element.dataset[valueLabel] === expectedValue) {
-                    scroll += (_element.offsetWidth + marginLeft + marginRight) / 2;
-                    break;
-                }
-
-                // increments the scroll value with the width of the component,
-                // which is composed by both the offset width and the margins
-                scroll += _element.offsetWidth + marginLeft + marginRight;
-            }
-
-            const padding = parseFloat(getComputedStyle(elementsContainer).paddingLeft);
-            const scrollableElementWidth = elementsContainer.clientWidth - padding;
-
-            elementsContainer.scrollLeft = scroll - scrollableElementWidth / 2 + padding / 2;
-        },
         configName(part) {
             return part.split("_").join(" ");
         },
@@ -794,10 +779,7 @@ export const Pickers = {
             this.$bus.trigger("highlight_part", part);
             this.onMaterialsChanged();
             this.onColorsChanged();
-
-            const partsPicker = this.$refs.partsPicker;
-            const parts = partsPicker.querySelectorAll(".button-part");
-            this.centerElement(partsPicker, parts, "part", this.activePart);
+            this.centerParts();
         },
         selectSwatch() {
             const removeOptional = this.activeColor.startsWith("no_");
@@ -881,6 +863,41 @@ export const Pickers = {
                   materialsPicker.clientWidth / 2
                 : 0;
             materialsPicker.style.scrollBehavior = smooth ? "auto" : null;
+        },
+        centerElement(elementsContainer, elements, valueLabel, expectedValue) {
+            let scroll = 0;
+            for (const _element of elements) {
+                const style = getComputedStyle(_element);
+                const marginLeft = parseFloat(style.marginLeft);
+                const marginRight = parseFloat(style.marginRight);
+
+                // centers the selected element in the middle of the container
+                if (_element.dataset[valueLabel] === expectedValue) {
+                    scroll += (_element.offsetWidth + marginLeft + marginRight) / 2;
+                    break;
+                }
+
+                // increments the scroll value with the width of the component,
+                // which is composed by both the offset width and the margins
+                scroll += _element.offsetWidth + marginLeft + marginRight;
+            }
+
+            const padding = parseFloat(getComputedStyle(elementsContainer).paddingLeft);
+            const scrollableElementWidth = elementsContainer.clientWidth - padding;
+
+            elementsContainer.scrollLeft = scroll - scrollableElementWidth / 2 + padding / 2;
+        },
+        centerParts() {
+            if (!this.enableCenterParts) return;
+            const partsPicker = this.$refs.partsPicker;
+            const parts = partsPicker.querySelectorAll(".button-part");
+            this.centerElement(partsPicker, parts, "part", this.activePart);
+        },
+        centerMaterials() {
+            if (!this.enableCenterMaterials) return;
+            const materialsPicker = this.$refs.materialsPicker;
+            const materials = materialsPicker.querySelectorAll(".button-material");
+            this.centerElement(materialsPicker, materials, "material", this.activeMaterial);
         },
         /**
          * Centers the active color inside its scrollable container.
@@ -1002,10 +1019,7 @@ export const Pickers = {
             const materialChanged = this.activeMaterial !== material;
             this.activeMaterial = material;
 
-            const materialsPicker = this.$refs.materialsPicker;
-            const materials = materialsPicker.querySelectorAll(".button-material");
-            this.centerElement(materialsPicker, materials, "material", this.activeMaterial);
-
+            this.centerMaterials();
             scroll &&
                 requestAnimationFrame(() => {
                     this.scrollMaterials(material);

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -965,6 +965,9 @@ export const Pickers = {
                 this.centerActiveColor();
                 return;
             }
+
+            // gathers the reference to the proper colors picker and obtains
+            // the references to the complete set of color elements
             const colorsPicker = this.$refs.colorsPicker;
             const colors = colorsPicker.querySelectorAll(".button-color-option");
 

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -1018,7 +1018,6 @@ export const Pickers = {
             scroll = scroll === undefined ? this.multipleMaterials : scroll;
             const materialChanged = this.activeMaterial !== material;
             this.activeMaterial = material;
-
             this.centerMaterials();
             scroll &&
                 requestAnimationFrame(() => {

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -708,6 +708,29 @@ export const Pickers = {
             const colors = colorsPicker.querySelectorAll(".button-color-option");
             this.slideRight(colorsPicker, colors);
         },
+        centerElement(elementsContainer, elements, valueLabel, expectedValue) {
+            let scroll = 0;
+            for (const _element of elements) {
+                const style = getComputedStyle(_element);
+                const marginLeft = parseFloat(style.marginLeft);
+                const marginRight = parseFloat(style.marginRight);
+
+                // centers the selected element in the middle of the container
+                if (_element.dataset[valueLabel] === expectedValue) {
+                    scroll += (_element.offsetWidth + marginLeft + marginRight) / 2;
+                    break;
+                }
+
+                // increments the scroll value with the width of the component,
+                // which is composed by both the offset width and the margins
+                scroll += _element.offsetWidth + marginLeft + marginRight;
+            }
+
+            const padding = parseFloat(getComputedStyle(elementsContainer).paddingLeft);
+            const scrollableElementWidth = elementsContainer.clientWidth - padding;
+
+            elementsContainer.scrollLeft = scroll - scrollableElementWidth / 2 + padding / 2;
+        },
         configName(part) {
             return part.split("_").join(" ");
         },
@@ -771,6 +794,10 @@ export const Pickers = {
             this.$bus.trigger("highlight_part", part);
             this.onMaterialsChanged();
             this.onColorsChanged();
+
+            const partsPicker = this.$refs.partsPicker;
+            const parts = partsPicker.querySelectorAll(".button-part");
+            this.centerElement(partsPicker, parts, "part", this.activePart);
         },
         selectSwatch() {
             const removeOptional = this.activeColor.startsWith("no_");
@@ -974,6 +1001,11 @@ export const Pickers = {
             scroll = scroll === undefined ? this.multipleMaterials : scroll;
             const materialChanged = this.activeMaterial !== material;
             this.activeMaterial = material;
+
+            const materialsPicker = this.$refs.materialsPicker;
+            const materials = materialsPicker.querySelectorAll(".button-material");
+            this.centerElement(materialsPicker, materials, "material", this.activeMaterial);
+
             scroll &&
                 requestAnimationFrame(() => {
                     this.scrollMaterials(material);

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -773,13 +773,13 @@ export const Pickers = {
             }
             this.swatches = swatches;
         },
-        selectPart(part) {
+        selectPart(part, center = true) {
             this.activePart = part;
             this.$bus.trigger("picker_part", part);
             this.$bus.trigger("highlight_part", part);
             this.onMaterialsChanged();
             this.onColorsChanged();
-            this.centerParts();
+            if (center) this.centerParts();
         },
         selectSwatch() {
             const removeOptional = this.activeColor.startsWith("no_");
@@ -908,9 +908,7 @@ export const Pickers = {
 
             const part = this.parts[this.activePart];
 
-            if (!part) {
-                return;
-            }
+            if (!part) return;
 
             if (part && part.material !== this.activeMaterial) {
                 colorsPicker.scrollLeft = 0;
@@ -921,7 +919,7 @@ export const Pickers = {
 
             let scrollActiveColor = 0;
             for (const _color of colors) {
-                // ignore all elements being transitioned out
+                // ignores all elements being transitioned out
                 if (_color.dataset.material !== this.activeMaterial) {
                     continue;
                 }
@@ -983,6 +981,7 @@ export const Pickers = {
                     }
                     break;
                 }
+
                 // offset width doesn't account for the margins, so we must sum them explicitly
                 scrollLeft += _color.offsetWidth + marginLeft + marginRight;
             }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/673 |
| Dependencies | -- |
| Decisions | Applying the same centering logic of the color pickers to parts and materials. There were experiments made with other logic, such as using the `offsetLeft` of the element to calculate the `scrollLeft`, but it ended up being way more complicated than the final solution. <br> The `centerActiveColor` function was not refactored to use the new function `centerElement` because it contains specific logic inside the scroll incrementing loop. |
| Animated GIF | ![pickers-scroll-center](https://user-images.githubusercontent.com/25725586/100126301-b05f0280-2e75-11eb-95c5-524ec183d7ff.gif)![scroll-parts-center](https://user-images.githubusercontent.com/25725586/100126329-b94fd400-2e75-11eb-85db-487c224a25a5.gif) |
