### PR TITLE
Remove unnecessary permutations for not compatbility

### DIFF
--- a/js/locale/model-locale-resolver.js
+++ b/js/locale/model-locale-resolver.js
@@ -135,19 +135,16 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
         }
 
         const prefixes = [`${brand}.${model}`, brand];
-        for (const value of values) {
-            const permutations = this._permutations(value);
-            for (const _prefix of prefixes) {
-                for (const _value of permutations) {
-                    const valueFqn = `${prefix}.${_prefix}.${_value}`;
-                    const hasLocale = this.localePlugin.hasLocale(valueFqn, locale);
-                    if (!hasLocale) {
-                        continue;
-                    }
-                    const result = this.localePlugin.toLocale(valueFqn, null, locale, fallback);
-                    if (result) {
-                        return result;
-                    }
+        for (const _prefix of prefixes) {
+            for (const _value of values) {
+                const valueFqn = `${prefix}.${_prefix}.${_value}`;
+                const hasLocale = this.localePlugin.hasLocale(valueFqn, locale);
+                if (!hasLocale) {
+                    continue;
+                }
+                const result = this.localePlugin.toLocale(valueFqn, null, locale, fallback);
+                if (result) {
+                    return result;
                 }
             }
         }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/697 |
| Decisions | Remove unnecessary permutations that cause bad precedence as explained in https://github.com/ripe-tech/ripe-white/issues/697#issuecomment-734796046 . This way, it iterates over the array it receives and in case of compatibility being true which is good for some legacy cases it will use permutations. For every case that I have tested in ripe-white, there's no need to use permutations but for some legacy and other reasons that I can't test every build, model, part, material and color, it might be a good idea to keep it. |
| Animated GIF | Below |

### Before
![image](https://user-images.githubusercontent.com/24736423/100452408-ff44ac00-30b0-11eb-85dd-c0215b6b0ca0.png)

### After
![image](https://user-images.githubusercontent.com/24736423/100452444-0ff52200-30b1-11eb-8c75-bf22cdcbb8d5.png)
