### PR TITLE
Hide group label when there is a single group

### DIFF
--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -8,7 +8,7 @@
         />
         <div class="form">
             <div class="form-group" v-for="group in groups" v-bind:key="group">
-                <p class="subtitle">
+                <p class="subtitle" v-if="showGroupLabel(group)">
                     {{ locale("ripe_commons.personalization.group") }}
                     {{ locale(`ripe_commons.group.${group}`, readable(capitalize(group))) }}
                 </p>
@@ -307,6 +307,9 @@ export const Reference = {
             Object.entries(valuesM).forEach(([property, value]) => {
                 this.onValueUpdate(value, group, property);
             });
+        },
+        showGroupLabel(group) {
+            return this.groups.length > 1 && group !== "main";
         },
         onValueUpdate(value, group, type) {
             const newProperties = { ...this.propertiesData };


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Asked by @joamag  |
| Decisions | Hide the label for `main` or when there is a single group. |
| Animated GIF | ![image](https://user-images.githubusercontent.com/3048875/100474785-552d4a00-30d9-11eb-8eba-eecaca12a764.png) |
