### PR TITLE
#698 Add validation reset on pre_config

### DIFF
--- a/vue/components/organisms/personalization/personalization.vue
+++ b/vue/components/organisms/personalization/personalization.vue
@@ -242,6 +242,7 @@ export const Personalization = {
         this.$bus.bind("pre_config", () => {
             this.enabled = false;
             this.form = null;
+            this.valid = true;
         });
 
         this.$bus.bind("post_config", async (config, options) => {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/698 |
| Decisions | Reset valid state when config changes - `pre_config`. |
| Animated GIF | ![Peek 2020-11-27 18-03](https://user-images.githubusercontent.com/24736423/100475848-07fea780-30dc-11eb-8fef-0af748f46b9a.gif) |
