### PR TITLE
#689 Fix square swatches for webkit

### DIFF
--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -297,7 +297,7 @@
     position: absolute;
     right: 0px;
     top: 0px;
-    transform: scale(1, 1);
+    transform: scale(1, 1) translateZ(0);
     transition: transform 0.125s ease-in-out, border-width 0.125s ease-in-out;
     width: 58px;
     z-index: 1;


### PR DESCRIPTION

| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/689 |
| Decisions | Add translateZ to swatch picker as suggested in https://github.com/ripe-tech/ripe-white/issues/689#issuecomment-732071519 |
| Animated GIF | Below |

### Before
![ezgif-1-53b04b097a9d](https://user-images.githubusercontent.com/24736423/101630331-aa8f2280-3a1a-11eb-824b-5f4f75bdb58f.gif)

### After
![ezgif-1-0c97c71651ff](https://user-images.githubusercontent.com/24736423/101630342-ad8a1300-3a1a-11eb-99a3-1fdd4e64dbf2.gif)
