### PR TITLE
Fix multiple validate/purchase calls

### DIFF
--- a/vue/components/organisms/size/size.vue
+++ b/vue/components/organisms/size/size.vue
@@ -118,7 +118,9 @@ export const Size = {
             this.closeCallback = callback;
             this.showModal();
         });
-        this.$bus.bind("close_size", () => {
+        this.$bus.bind("close_size", id => {
+            if (id === this._uid) return;
+            if (!this.visible) this.closeCallback = null;
             this.hideModal();
         });
 
@@ -216,7 +218,7 @@ export const Size = {
 
             // triggers the close size event and the hides the form of the
             // managed by the "external" plugin
-            this.$bus.trigger("close_size");
+            this.$bus.trigger("close_size", this._uid);
             this.$refs.form.hide();
         },
         modalHidden() {

--- a/vue/components/organisms/size/size.vue
+++ b/vue/components/organisms/size/size.vue
@@ -119,7 +119,12 @@ export const Size = {
             this.showModal();
         });
         this.$bus.bind("close_size", id => {
+            // if this was the component instance that
+            // originated the closing request, ignore it
             if (id === this._uid) return;
+
+            // the closing callback should only run when
+            // the modal is visible
             if (!this.visible) this.closeCallback = null;
             this.hideModal();
         });


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Multiple white-manager `purchase` calls were being made, resulting in duplicate `validate` calls. |
