### PR TITLE
Fix engraving without initials

### DIFF
--- a/vue/components/organisms/personalization/personalization.vue
+++ b/vue/components/organisms/personalization/personalization.vue
@@ -380,10 +380,10 @@ export const Personalization = {
             // updates the current state object with both initials, engraving
             // and the initials extra structure, either from the direct provided
             // state or from the conversion from the "simple" initials
-            state.initials = initials;
-            state.engraving = engraving;
-            state.initialsExtra =
-                state.initialsExtra || this.initialsToInitialsExtra(initials, engraving);
+            [state.initials, state.engraving] = this.sanitizeInitials(initials, engraving);
+            state.initialsExtra = state.initialsExtra
+                ? this.sanitizeInitialsExtra(state.initialsExtra)
+                : this.initialsToInitialsExtra(initials, engraving);
 
             // updates both the current internal state taking into account if an event
             // should be triggered or not (using internal state values)
@@ -471,7 +471,7 @@ export const Personalization = {
             // if no group has valid initials then returns empty values
             return {
                 initials: "",
-                engraving: ""
+                engraving: null
             };
         }
     }

--- a/vue/components/organisms/personalization/personalization.vue
+++ b/vue/components/organisms/personalization/personalization.vue
@@ -379,7 +379,9 @@ export const Personalization = {
 
             // updates the current state object with both initials, engraving
             // and the initials extra structure, either from the direct provided
-            // state or from the conversion from the "simple" initials
+            // state or from the conversion from the "simple" initials, notice
+            // that both the initials and the initials extra are sanitized to avoid
+            // corrupted data regarding initials and initials extra
             [state.initials, state.engraving] = this.sanitizeInitials(initials, engraving);
             state.initialsExtra = state.initialsExtra
                 ? this.sanitizeInitialsExtra(state.initialsExtra)

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -185,9 +185,10 @@ export const logicMixin = {
         sanitizeInitials(initials, engraving) {
             return [initials || "", initials ? engraving || null : null];
         },
-        sanitizeInitialsExtra(initialsExtra) {
+        sanitizeInitialsExtra(initialsExtra, minimize = true) {
             const initialsExtraS = {};
             Object.entries(initialsExtra).forEach(([group, { initials, engraving }]) => {
+                if (!initials && minimize) return;
                 initialsExtraS[group] = {
                     initials: initials || "",
                     engraving: initials ? engraving || null : null


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issues | https://github.com/ripe-tech/ripe-retail-vendors/issues/97 <br/> https://github.com/ripe-tech/ripe-white/issues/714 |
| Decisions | Use the existing sanitization so that it can cope with plugins that send an invalid state (having engraving without initials). |
