### PR TITLE
Fixed infinite loop in personalizationChanged

### DIFF
--- a/vue/components/organisms/personalization/personalization.vue
+++ b/vue/components/organisms/personalization/personalization.vue
@@ -383,9 +383,12 @@ export const Personalization = {
             // that both the initials and the initials extra are sanitized to avoid
             // corrupted data regarding initials and initials extra
             [state.initials, state.engraving] = this.sanitizeInitials(initials, engraving);
-            state.initialsExtra = state.initialsExtra
-                ? this.sanitizeInitialsExtra(state.initialsExtra)
-                : this.initialsToInitialsExtra(initials, engraving);
+            state.initialsExtra =
+                state.initialsExtra || this.initialsToInitialsExtra(initials, engraving);
+            const sanitizedInitialsExtra = this.sanitizeInitialsExtra(state.initialsExtra);
+            if (this.diffInitialsExtra(sanitizedInitialsExtra, state.initialsExtra)) {
+                state.initialsExtra = sanitizedInitialsExtra;
+            }
 
             // updates both the current internal state taking into account if an event
             // should be triggered or not (using internal state values)


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | [This](https://github.com/ripe-tech/ripe-commons-pluginus/blob/master/vue/components/organisms/personalization/personalization.vue#L386) was causing the `personalizationChanged` to be constantly triggered. |
| Decisions | Instead of always assigning the result of `sanitizeInitialsExtra`, it always checks the value is different from the previous value and then decides if it needs to be reassigned. |
| Screenshot | <img src="https://user-images.githubusercontent.com/10127604/102391596-d76ca800-3fcd-11eb-8ab1-a1df2fd8c260.png">|
