### PR TITLE
fix: fix locale reactivity by using a defensive copy

### DIFF
--- a/vue/plugins/locale.js
+++ b/vue/plugins/locale.js
@@ -33,10 +33,10 @@ export const localePlugin = {
                 localePlugin.owner.bind("post_set_locale", locale => (this.currentLocale = locale));
                 localePlugin.owner.bind(
                     "locale_map_changed",
-                    () => (this.localeMap = localePlugin.localeMap)
+                    () => (this.localeMap = Object.assign({}, localePlugin.localeMap))
                 );
                 this.currentLocale = localePlugin.locale;
-                this.localeMap = localePlugin.localeMap;
+                this.localeMap = Object.assign({}, localePlugin.localeMap);
             }
         });
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Locales were not reactive once again after https://github.com/ripe-tech/ripe-commons-pluginus/pull/209 due to https://github.com/ripe-tech/ripe-commons-pluginus/commit/007543865c179e911fa071cf6b5e11296a9a1224. This was because the same object was assigned in both instances. |

