### PR TITLE
#673: Fix colors scroll behaviour and materials arrows in desktop

### DIFF
--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -902,9 +902,14 @@ export const Pickers = {
          * in the right or left direction.
          */
         slideCentered(container, elements, valueLabel, right = true) {
+            // support for aligned sslide in the colors container, which
+            // has another container inside it
+            const scrollableContainer =
+                valueLabel === "color" ? container.querySelector("span") : container;
+
             // calculates the width of the container without the padding
             // allowing for precise calculations to center the elements
-            const containerStyle = getComputedStyle(container);
+            const containerStyle = getComputedStyle(scrollableContainer);
             const paddingRight = parseFloat(containerStyle.paddingRight);
             const paddingLeft = parseFloat(containerStyle.paddingLeft);
             const containerWidth = container.offsetWidth - paddingRight - paddingLeft;

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -902,7 +902,7 @@ export const Pickers = {
          * in the right or left direction.
          */
         slideCentered(container, elements, valueLabel, right = true) {
-            // support for aligned sslide in the colors container, which
+            // support for aligned slide in the colors container, which
             // has another container inside it
             const scrollableContainer =
                 valueLabel === "color" ? container.querySelector("span") : container;

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -240,6 +240,10 @@
     position: relative;
 }
 
+.pickers .materials-wrapper .materials-container {
+    width: 100%;
+}
+
 .pickers .materials-wrapper .materials-container.hidden {
     display: none;
 }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/673#issuecomment-762817148 |
| Dependencies | -- |
| Decisions | Two fixes (joined in this PR because they originated from the same issue and are very small): <br> - Materials scroll arrows appearing on desktop mode (fix with `width: 100%`); <br> - Fix smooth scrolling alignment in colors pickers (colors container has a transition-group, which adds a `span`, this had to be taken into account when implementing the `slideCentered` behaviour). <br><br> PR with the other fixes will be made in ripe-white (transparency in the scroll arrow buttons and smooth scrolling on colors)  |
| Animated GIF | Working: <br> ![scroll_colors](https://user-images.githubusercontent.com/25725586/105329986-afbec000-5bc9-11eb-863b-b20380423033.gif)<br> Scroll on materials in desktop mode: <br>![Screenshot_2021-01-20 RIPE White(3)](https://user-images.githubusercontent.com/25725586/105330843-a97d1380-5bca-11eb-9d67-7f4fdbc22851.png)|
