### PR TITLE
#673: Polish picker scroll arrows

### DIFF
--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -1210,15 +1210,14 @@ export const Pickers = {
             scroll = scroll === null ? this.multipleMaterials : scroll;
             const materialChanged = this.activeMaterial !== material;
             this.activeMaterial = material;
-            if (center) this.centerMaterials();
-            if (scroll) {
+            if (scroll || center) {
                 requestAnimationFrame(() => {
+            if (center) this.centerMaterials();
+                    if (!scroll) return;
+
                     this.scrollMaterials(material);
-                    if (this.colorToggle && materialChanged) {
+                    if (!this.colorToggle || materialChanged) return;
                         this.scrollColors(material);
-                    } else {
-                        this.scrollColors(material);
-                    }
                 });
             }
         },

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -1212,12 +1212,12 @@ export const Pickers = {
             this.activeMaterial = material;
             if (scroll || center) {
                 requestAnimationFrame(() => {
-            if (center) this.centerMaterials();
+                    if (center) this.centerMaterials();
                     if (!scroll) return;
 
                     this.scrollMaterials(material);
                     if (!this.colorToggle || materialChanged) return;
-                        this.scrollColors(material);
+                    this.scrollColors(material);
                 });
             }
         },

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -563,6 +563,13 @@ export const Pickers = {
     watch: {
         parts() {
             this.updateSwatches();
+
+            // scrolls to the selected color after
+            // updating the parts, allowing centering
+            // of the selected color after choosing
+            // a color of a different material than the
+            // previous one
+            this.scrollColors(this.activeMaterial);
         },
         options() {
             this.updateSwatches();
@@ -1122,7 +1129,7 @@ export const Pickers = {
 
             if (!part) return;
 
-            if (part && part.material !== this.activeMaterial) {
+            if (part.material !== this.activeMaterial) {
                 colorsPicker.scrollLeft = 0;
                 return;
             }
@@ -1237,9 +1244,11 @@ export const Pickers = {
             this.$emit(buttonEvent, event);
         },
         onMaterialsChanged() {
-            this.scrollMaterials(this.activeMaterial, false);
-            this.scrollColors(this.activeMaterial, null, false);
-            this.updateScrollFlags();
+            requestAnimationFrame(() => {
+                this.scrollMaterials(this.activeMaterial, false);
+                this.scrollColors(this.activeMaterial, null, false);
+                this.updateScrollFlags();
+            });
         },
         onColorsChanged() {
             requestAnimationFrame(() => {

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -1254,6 +1254,11 @@ export const Pickers = {
             // are finalized and the dataset it set
             if (element.dataset.index < this.colorOptions.length - 1) return;
             this.updateScrollFlags();
+
+            // centers the existing active color after the last element
+            // in the list enter the animation, so that the number of
+            // elements is correct
+            if (this.activeColor) this.scrollColors(this.activeMaterial, null, false);
         },
         /**
          * Finds the element closer to the center of the container depending

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -562,13 +562,13 @@ export const Pickers = {
     },
     watch: {
         parts() {
+            // triggers the update of the swatch values according
+            // to the newly set parts
             this.updateSwatches();
 
-            // scrolls to the selected color after
-            // updating the parts, allowing centering
-            // of the selected color after choosing
-            // a color of a different material than the
-            // previous one
+            // scrolls to the selected color after updating the parts,
+            // allowing centering of the selected color after choosing
+            // a color of a different material than the previous one
             this.scrollColors(this.activeMaterial);
         },
         options() {

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -1243,10 +1243,10 @@ export const Pickers = {
             this.updateScrollFlags();
         },
         onColorsChanged() {
-            this.updateScrollFlags();
             requestAnimationFrame(() => {
                 this.scrollMaterials(this.activeMaterial, false);
                 this.scrollColors(this.activeMaterial, null, false);
+                this.updateScrollFlags();
             });
         },
         onColorsAnimationAfterEnter(element) {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/673#issuecomment-765347573 |
| Dependencies | -- |
| Decisions | The fix for the **point 3** (materials arrows not working in intermediate sizes) is https://github.com/ripe-tech/ripe-commons-pluginus/blob/0bb1202f0149919ec07370df1d2580ec5c41f645/vue/components/organisms/pickers/pickers.vue#L1254-L1258 <br> The change in https://github.com/ripe-tech/ripe-commons-pluginus/blob/0bb1202f0149919ec07370df1d2580ec5c41f645/vue/components/organisms/pickers/pickers.vue#L1247-L1251 is to make it similar to be `onColorsChanged`, since it may cause the same problem in the future. <br><hr><br> The **point 6** (center in select material and color if there was already one selected) is a new feature, which was implemented in lines https://github.com/ripe-tech/ripe-commons-pluginus/blob/0bb1202f0149919ec07370df1d2580ec5c41f645/vue/components/organisms/pickers/pickers.vue#L1221-L1228 and https://github.com/ripe-tech/ripe-commons-pluginus/blob/0bb1202f0149919ec07370df1d2580ec5c41f645/vue/components/organisms/pickers/pickers.vue#L1270 <br><hr><br> Finally, a bug was found (in the Animated GIF part) was found, and the solution for it is in line https://github.com/ripe-tech/ripe-commons-pluginus/blob/0bb1202f0149919ec07370df1d2580ec5c41f645/vue/components/organisms/pickers/pickers.vue#L567-L572 |
| Animated GIF | Pickers centering in previously selected options: <br> ![pickers-centering-fix](https://user-images.githubusercontent.com/25725586/106873464-66dc3080-66cc-11eb-97f4-f554c8e64b11.gif)<br><hr><br>Bug mentioned in the end of decision: <br> ![problem-pickers-1](https://user-images.githubusercontent.com/25725586/106873385-51ff9d00-66cc-11eb-8aa7-006b825ee67d.gif) <br> Solution: <br> ![problem-pickers-1-solution](https://user-images.githubusercontent.com/25725586/106873418-59bf4180-66cc-11eb-867e-3942986b3952.gif)

|
