### PR TITLE
Fix storybook component search

### DIFF
--- a/vue/components/atoms/button-platforme/button-platforme.stories.js
+++ b/vue/components/atoms/button-platforme/button-platforme.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, boolean } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Button Platforme", module)
     .addDecorator(withKnobs)
     .add("Button Platforme", () => ({
         props: {

--- a/vue/components/atoms/button/button.stories.js
+++ b/vue/components/atoms/button/button.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, boolean, select } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Button", module)
     .addDecorator(withKnobs)
     .add("Button", () => ({
         props: {

--- a/vue/components/atoms/icon/icon.stories.js
+++ b/vue/components/atoms/icon/icon.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, number, color } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Icon", module)
     .addDecorator(withKnobs)
     .add("Icon", () => ({
         props: {

--- a/vue/components/atoms/image/image.stories.js
+++ b/vue/components/atoms/image/image.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, text } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Image", module)
     .addDecorator(withKnobs)
     .add("Image", () => ({
         props: {

--- a/vue/components/atoms/loader/loader.stories.js
+++ b/vue/components/atoms/loader/loader.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, color, number } from "@storybook/addon-knobs";
 
-storiesOf("Atoms", module)
+storiesOf("Components/Atoms/Loader", module)
     .addDecorator(withKnobs)
     .add("Loader Ball Pulse", () => ({
         props: {

--- a/vue/components/molecules/keyboard/keyboard.stories.js
+++ b/vue/components/molecules/keyboard/keyboard.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from "@storybook/vue";
 import { withKnobs, boolean, object } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Keyboard", module)
     .addDecorator(withKnobs)
     .add("Keyboard", () => ({
         props: {

--- a/vue/components/molecules/thumbnails-groups/thumbnails-groups.stories.js
+++ b/vue/components/molecules/thumbnails-groups/thumbnails-groups.stories.js
@@ -2,7 +2,7 @@ import { storiesOf } from "@storybook/vue";
 import Vuex from "vuex";
 import { withKnobs } from "@storybook/addon-knobs";
 
-storiesOf("Molecules", module)
+storiesOf("Components/Molecules/Thumbnails Groups", module)
     .addDecorator(withKnobs)
     .add("Thumbnails Groups", () => ({
         props: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-twitch-ui/pull/74#issuecomment-771513137 <br> Fix to to pass the component title path in storiesOf() first argument and the story name in add() first argument. This fixes component search. Reference: https://github.com/storybookjs/storybook/blob/next/lib/core/docs/storiesOf.md#storiesof-api |

