### PR TITLE
#673: Fix center same material

### DIFF
--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -1221,16 +1221,11 @@ export const Pickers = {
         },
         selectMaterial(material, scroll = null, center = true) {
             scroll = scroll === null ? this.multipleMaterials : scroll;
-            const materialChanged = this.activeMaterial !== material;
             this.activeMaterial = material;
             if (scroll || center) {
                 requestAnimationFrame(() => {
                     if (center) this.centerMaterials();
-                    if (!scroll) return;
-
-                    this.scrollMaterials(material);
-                    if (!this.colorToggle || materialChanged) return;
-                    this.scrollColors(material);
+                    if (scroll) this.scrollMaterials(material);
                 });
             }
         },

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -593,6 +593,12 @@ export const Pickers = {
             const materialSelected = current && current.material;
             const material = materialSelected ? current.material : materials[0];
             this.selectMaterial(material, false);
+
+            // if the material stays the same, it updates the color
+            // in case there is previously defined color
+            if (current && current.material === this.activeMaterial) {
+                this.activeColor = current.color;
+            }
         },
         activeMaterial(material) {
             const current = this.parts[this.activePart];

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -942,15 +942,16 @@ export const Pickers = {
             this._sumElementsWidth(
                 elements,
                 (element, index, elementWidth, width) => {
-                    // if the element middle is after the middle of the container, it is
-                    // the next element, so its center will be positioned at the middle
+                    // if the element middle is after the middle of the container by more or
+                    // equal than 1 pixel (to avoid catching the element that is already centered)
+                    // it is the next element, so its center will be positioned at the middle
                     // of the container element
-                    if (Math.floor(width + elementWidth / 2) > containerCenter) {
-                        slide = width + elementWidth / 2 - containerCenter;
-                        this[`aligned${this.capitalize(valueLabel)}`] = element.dataset[valueLabel];
-                        return true;
-                    }
-                    return false;
+                    const diff = width + elementWidth / 2 - containerCenter;
+                    if (diff < 1) return false;
+
+                    slide = diff;
+                    this[`aligned${this.capitalize(valueLabel)}`] = element.dataset[valueLabel];
+                    return true;
                 },
                 !right
             );


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/673#issuecomment-776180527 |
| Dependencies | -- |
| Decisions | - Resolved the problem in **point 6**, which was when the material stayed the same, the `activeMaterial` watcher was not triggered and the colors scroll didn't happen. <br> - Resolved **point 3**, where in some cases the scroll left and right were not working due to small differences in the `_sumElementsWidth` stop condition. The currently centered element was being chosen as the next one and the slide delta was 0. <br> - Also found another problem showcased in the GIFs below and it was fixed by removing a `scrollColors` call that was happening before the `parts` were updated. <br><br> @msp-platforme tested and gave the all clear regarding the 2 points mentioned in the issue. |
| Animated GIF | Problem encontered: <br> ![problem-pickers-scroll](https://user-images.githubusercontent.com/25725586/107632282-32351f80-6c5e-11eb-90a5-25308deb7807.gif) <br> After fix: <br> ![problem-pickers-scroll-solution](https://user-images.githubusercontent.com/25725586/107632381-54c73880-6c5e-11eb-9f8f-4561dbcea2a5.gif)|
