### PR TITLE
#673: scrollColors when colorToggle is false

### DIFF
--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -240,10 +240,6 @@
     position: relative;
 }
 
-.pickers .materials-wrapper .materials-container {
-    width: 100%;
-}
-
 .pickers .materials-wrapper .materials-container.hidden {
     display: none;
 }

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -1222,11 +1222,17 @@ export const Pickers = {
         },
         selectMaterial(material, scroll = null, center = true) {
             scroll = scroll === null ? this.multipleMaterials : scroll;
+            const materialChanged = this.activeMaterial !== material;
             this.activeMaterial = material;
             if (scroll || center) {
                 requestAnimationFrame(() => {
                     if (center) this.centerMaterials();
                     if (scroll) this.scrollMaterials(material);
+
+                    // scroll the colors if material has changed and
+                    // if all the colors of all materials are shown
+                    if (this.colorToggle || !materialChanged) return;
+                    this.scrollColors(material);
                 });
             }
         },

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -1225,10 +1225,12 @@ export const Pickers = {
                     if (center) this.centerMaterials();
                     if (scroll) this.scrollMaterials(material);
 
-                    // scroll the colors if material has changed and
-                    // if all the colors of all materials are shown
-                    if (this.colorToggle || !materialChanged) return;
-                    this.scrollColors(material);
+                    // scrolls the colors if material have changed and if
+                    // all the colors of all materials are shown (no color
+                    // toggle is currently in display)
+                    if (materialChanged && !this.colorToggle) {
+                        this.scrollColors(material);
+                    }
                 });
             }
         },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Second issue in https://github.com/ripe-tech/ripe-white/issues/673#issuecomment-778146310 |
| Dependencies | -- |
| Decisions |  Previous PR I had removed a piece of code that scrolled the colors after a material had been selected. This piece of code is necessary in retail since the transitions that happen in white do not happen in retail, not triggering the `onMaterialsChanged` function. <br> The function call was added but the conditional was fixed, so that only happens when `colorToggle` is `false`, which is what happens in retail (all colors appear instead of only the colors of the selected material). |
| Animated GIF | Now: <br> ![pickers-scroll-fix-retail](https://user-images.githubusercontent.com/25725586/108061315-05af4800-7050-11eb-90e8-91f779153d75.gif)|
