### PR TITLE
#768 Fix configurator options reactivity

### DIFF
--- a/vue/components/organisms/configurator/configurator.vue
+++ b/vue/components/organisms/configurator/configurator.vue
@@ -400,6 +400,9 @@ export const Configurator = {
         },
         loading(value) {
             this.$emit("update:loading", value);
+        },
+        options(value) {
+            this.configurator.updateOptions(value);
         }
     },
     methods: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/768  <br> When changing `options` prop, it has no effect in the configurator. |
| Decisions | Add watcher to options to update configurator options via `configurator.updateOptions`. |
