### PR TITLE
#768 Fix overriding store resolution with undefined after init

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -329,7 +329,7 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
                 parts: this.ripe.parts || {}
             });
             this.store.commit("format", this.ripe.format);
-            this.store.commit("resolution", this.ripe.size);
+            if (this.ripe.size !== undefined) this.store.commit("resolution", this.ripe.size);
             this.store.commit("backgroundColor", this.ripe.backgroundColor);
             this.store.commit("ripeOptions", this.ripe.options);
             this.store.commit("ripeState", {

--- a/js/base/main.js
+++ b/js/base/main.js
@@ -383,7 +383,7 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
         this.ripe.bind("settings", () => {
             this.app.logDebug(() => "SDK settings changed");
             this.store.commit("format", this.ripe.format);
-            this.store.commit("resolution", this.ripe.size);
+            if (this.ripe.size !== undefined) this.store.commit("resolution", this.ripe.size);
             this.store.commit("backgroundColor", this.ripe.backgroundColor);
         });
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/768 <br> After `ripe` init, the first `post_config` payload will always come with `undefined` size. This is because [config](https://github.com/ripe-tech/ripe-sdk/blob/master/src/js/base/ripe.js#L366) doesn't set `this.ripe.size` from the `options` arguments. The only way to set it after init is by calling `ripe.setSize()` or changing `store.state.resolution` which will have a watcher triggering `size_change` and in turn call `ripe.setSize()` (the way it's currently changing the resolution in technical settings). This will be problematic when we start committing values to the store in RIPE White's [_loadOptions](https://github.com/ripe-tech/ripe-white/blob/master/js/plugins/base/main.js#L167) which happens before `post_config` clears out the values we committed with `undefined`. This fixes the bug as resolution value will no longer be cleared by `undefined` [here](https://github.com/ripe-tech/ripe-commons-pluginus/blob/master/js/base/main.js#L332). A cleaner and more appropriate approach would be a new configurator prop `remoteSize` that would `ripeInstance.setSize` the resolution value it received. Using this approach we would also be able to get rid of the `size_change` watcher. |
| Dependencies | https://github.com/ripe-tech/ripe-sdk/pull/248 |
| Decisions | Add size to ripeState to allow us to change it with setOptions. |
