### PR TITLE
#761 Using hasInitialsRadius to control personalization image border radius

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -367,6 +367,7 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
             this.store.commit("hasCustomization", this.ripe.hasCustomization());
             this.store.commit("hasPersonalization", this.ripe.hasPersonalization());
             this.store.commit("hasSize", this.ripe.hasSize());
+            this.store.commit("hasInitialsRadius", this.ripe.hasInitialsRadius());
 
             // clear the initials data, as it is possibly outdated
             this.store.commit("clearInitialsData");

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -176,6 +176,9 @@ export const Reference = {
                 this.propertiesData,
                 this.properties()
             );
+        },
+        imageBorderRadius() {
+            return this.$store.state.hasInitialsRadius ? "50%" : "0px";
         }
     },
     watch: {

--- a/vue/store.js
+++ b/vue/store.js
@@ -40,6 +40,7 @@ export const store = {
         hasCustomization: false,
         hasPersonalization: false,
         hasSize: false,
+        hasInitialsRadius: true,
         ripeOptions: {},
         ripeState: {},
         initialsGroups: null,
@@ -148,6 +149,9 @@ export const store = {
         },
         hasSize(state, hasSize) {
             state.hasSize = hasSize;
+        },
+        hasInitialsRadius(state, hasInitialsRadius) {
+            state.hasInitialsRadius = hasInitialsRadius;
         },
         ripeOptions(state, ripeOptions) {
             state.ripeOptions = ripeOptions;

--- a/vue/store.js
+++ b/vue/store.js
@@ -40,7 +40,7 @@ export const store = {
         hasCustomization: false,
         hasPersonalization: false,
         hasSize: false,
-        hasInitialsRadius: true,
+        hasInitialsRadius: false,
         ripeOptions: {},
         ripeState: {},
         initialsGroups: null,


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/761 |
| Dependencies | https://github.com/ripe-tech/ripe-sdk/pull/247 |
| Decisions | Using hasInitialsRadius to control personalization image border radius as suggested by https://github.com/ripe-tech/ripe-white/issues/761#issuecomment-766660725  |
