### PR TITLE
#761 Fix duplicate borderRadius

### DIFF
--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -140,13 +140,7 @@ export const Reference = {
              * The height (in pixels) of the image that is going to be used to
              * display the personalization initials.
              */
-            imageHeight: 300,
-
-            /**
-             * The radius of the border for the image that is going to be used in
-             * the display of the initials.
-             */
-            imageBorderRadius: "50%"
+            imageHeight: 300
         };
     },
     computed: {
@@ -162,8 +156,13 @@ export const Reference = {
         configMeta() {
             return this.$store.state.config.meta || {};
         },
+        /**
+         * The radius of the border for the image that is going to be used in
+         * the display of the initials.
+         */
         imageBorderRadius() {
-            return this.$store.state.hasInitialsRadius ? "50%" : "0px";
+            if (!this.$store.state.hasInitialsRadius) return "0px";
+            return this.configMeta?.initials_image?.border_radius || "50%";
         },
         state() {
             return {
@@ -275,8 +274,6 @@ export const Reference = {
             // information present in the model's configuration (if existent)
             const initialsImage = this.configMeta.initials_image || {};
             this.imageHeight = initialsImage.height === undefined ? 300 : initialsImage.height;
-            this.imageBorderRadius =
-                initialsImage.border_radius === undefined ? "50%" : initialsImage.border_radius;
 
             try {
                 // runs the remote business logic to obtain the multiple

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -162,7 +162,8 @@ export const Reference = {
          */
         imageBorderRadius() {
             if (!this.$store.state.hasInitialsRadius) return "0px";
-            return this.configMeta?.initials_image?.border_radius || "50%";
+            const initialsImage = this.configMeta.initials_image || {};
+            return initialsImage.border_radius === undefined ? "50%" : initialsImage.border_radius;
         },
         state() {
             return {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | After https://github.com/ripe-tech/ripe-commons-pluginus/pull/223 I, by mistake, added a computed `imageBorderRadius` value without removing data's `imageBorderRadius` value and merging the old logic to use `initialsImage.border_radius` in case it existed. |
| Decisions | This deletes duplicate data `imageBorderRadius` and uses old logic in the computed. |
