### PR TITLE
#768 Fix setRipeOptions

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -266,7 +266,7 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
                 case "parts":
                     return options[key] && !this.app.equalParts(options[key], value);
                 default:
-                    return options[key] && options[key] !== value;
+                    return options[key] !== undefined && options[key] !== value;
             }
         });
         if (changed.length === 0 && !force) return;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/768 <br> When doing `store.commit("ripeState", { someOption: false })` which will call `setRipeOptions({ someOption: false })` it will never set `someOption` to `false` as `options[key] && options[key] !== value` will always evaluate to `false` but it should be evaluating to `true`. <br> This also fixes the bug in which none of the boolean settings in Technical Settings > RIPE SDK are curretly working when they're set to false. |
| Decisions | Fix check before setting ripe options. |
