### PR TITLE
#44 Using newly implemented ripe-sdk locale methods

### DIFF
--- a/js/locale/model-locale-resolver.js
+++ b/js/locale/model-locale-resolver.js
@@ -29,12 +29,14 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
     ) {
         const ripe = this.ripeProvider.ripe;
         return ripe.localeColor(color, this.localePlugin, {
-            part,
-            material,
-            locale,
-            defaultValue,
-            prefixes,
-            suffixes
+            brand: this.brand,
+            model: this.model,
+            part: part,
+            material: material,
+            locale: locale,
+            defaultValue: defaultValue,
+            prefixes: prefixes,
+            suffixes: suffixes
         });
     }
 
@@ -44,7 +46,7 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
     ) {
         const ripe = this.ripeProvider.ripe;
         return ripe.localeMaterial(material, this.localePlugin, {
-            bran: this.brand,
+            brand: this.brand,
             model: this.model,
             part: part,
             locale: locale,

--- a/js/locale/model-locale-resolver.js
+++ b/js/locale/model-locale-resolver.js
@@ -92,7 +92,7 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
             },
             options
         );
-        return this._toLocale(value, this.brand, this.model, options);
+        return this._toLocale(value, this.brand, this.model, this.localePlugin, options);
     }
 
     _bind() {
@@ -117,40 +117,14 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
         } = {}
     ) {
         const ripe = this.ripeProvider.ripe;
-        const values = Array.isArray(value) ? value : [value];
-        const result = ripe.localeModel(value, this.localePlugin, {
-            brand: brand,
-            model: model,
-            locale: locale,
-            defaultValue: defaultValue,
-            prefix: prefix,
-            fallback: fallback,
-            compatibility: compatibility,
-            hack: hack
+        ripe._toLocale(value, brand, model, this.localePlugin, {
+            locale,
+            defaultValue,
+            prefix,
+            fallback,
+            compatibility,
+            hack
         });
-
-        // if the localization was successful returns its result
-        if (result !== defaultValue) return result;
-
-        // if the localization was not successful but a default
-        // was defined, then returns it
-        if (defaultValue !== null) return result;
-
-        // otherwise run the localization process again using
-        // a fallback locale as the base for localization
-        const localeFallback = this.localePlugin.getLocaleFallback();
-        if (localeFallback !== locale) {
-            return this._toLocale(values, brand, model, {
-                locale: localeFallback,
-                defaultValue: defaultValue,
-                prefix: prefix,
-                fallback: fallback,
-                compatibility: compatibility,
-                hack: hack
-            });
-        }
-
-        return values[0];
     }
 }
 

--- a/js/locale/model-locale-resolver.js
+++ b/js/locale/model-locale-resolver.js
@@ -27,16 +27,14 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
             suffixes = []
         } = {}
     ) {
-        let value = [];
-        value = value.concat(prefixes);
-        part && material && color && value.push(`colors.${part}.${material}.${color}`);
-        part && color && value.push(`colors.${part}.${color}`);
-        material && color && value.push(`colors.${material}.${color}`);
-        color && value.push(`colors.${color}`);
-        value = value.concat(suffixes);
-        return this.localeModel(value, {
-            locale: locale,
-            defaultValue: defaultValue
+        const ripe = this.ripeProvider.ripe;
+        return ripe.localeColor(color, this.localePlugin, {
+            part,
+            material,
+            locale,
+            defaultValue,
+            prefixes,
+            suffixes
         });
     }
 
@@ -44,25 +42,27 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
         material,
         { part = null, locale = null, defaultValue = null, prefixes = [], suffixes = [] } = {}
     ) {
-        let value = [];
-        value = value.concat(prefixes);
-        part && material && value.push(`materials.${part}.${material}`);
-        material && value.push(`materials.${material}`);
-        value = value.concat(suffixes);
-        return this.localeModel(value, {
+        const ripe = this.ripeProvider.ripe;
+        return ripe.localeMaterial(material, this.localePlugin, {
+            bran: this.brand,
+            model: this.model,
+            part: part,
             locale: locale,
-            defaultValue: defaultValue
+            defaultValue: defaultValue,
+            prefixes: prefixes,
+            suffixes: suffixes
         });
     }
 
     localePart(part, { locale = null, defaultValue = null, prefixes = [], suffixes = [] } = {}) {
-        let value = [];
-        value = value.concat(prefixes);
-        part && value.push(`parts.${part}`);
-        value = value.concat(suffixes);
-        return this.localeModel(value, {
+        const ripe = this.ripeProvider.ripe;
+        return ripe.localePart(part, this.localePlugin, {
+            brand: this.brand,
+            model: this.model,
             locale: locale,
-            defaultValue: defaultValue
+            defaultValue: defaultValue,
+            prefixes: prefixes,
+            suffixes: suffixes
         });
     }
 
@@ -70,14 +70,15 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
         name,
         { type = null, locale = null, defaultValue = null, prefixes = [], suffixes = [] } = {}
     ) {
-        let value = [];
-        value = value.concat(prefixes);
-        name && value.push(`properties.${name}`);
-        type && name && value.push(`properties.${type}.${name}`);
-        value = value.concat(suffixes);
-        return this.localeModel(value, {
+        const ripe = this.ripeProvider.ripe;
+        return ripe.localeProperty(name, this.localePlugin, {
+            brand: this.brand,
+            model: this.model,
+            type: type,
             locale: locale,
-            defaultValue: defaultValue
+            defaultValue: defaultValue,
+            prefixes: prefixes,
+            suffixes: suffixes
         });
     }
 

--- a/js/locale/model-locale-resolver.js
+++ b/js/locale/model-locale-resolver.js
@@ -92,7 +92,7 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
             },
             options
         );
-        return this._toLocale(value, this.brand, this.model, this.localePlugin, options);
+        return this._toLocale(value, this.brand, this.model, options);
     }
 
     _bind() {
@@ -117,14 +117,40 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
         } = {}
     ) {
         const ripe = this.ripeProvider.ripe;
-        ripe._toLocale(value, brand, model, this.localePlugin, {
-            locale,
-            defaultValue,
-            prefix,
-            fallback,
-            compatibility,
-            hack
+        const values = Array.isArray(value) ? value : [value];
+        const result = ripe.localeModel(value, this.localePlugin, {
+            brand: brand,
+            model: model,
+            locale: locale,
+            defaultValue: defaultValue,
+            prefix: prefix,
+            fallback: fallback,
+            compatibility: compatibility,
+            hack: hack
         });
+
+        // if the localization was successful returns its result
+        if (result !== defaultValue) return result;
+
+        // if the localization was not successful but a default
+        // was defined, then returns it
+        if (defaultValue !== null) return result;
+
+        // otherwise run the localization process again using
+        // a fallback locale as the base for localization
+        const localeFallback = this.localePlugin.getLocaleFallback();
+        if (localeFallback !== locale) {
+            return this._toLocale(values, brand, model, {
+                locale: localeFallback,
+                defaultValue: defaultValue,
+                prefix: prefix,
+                fallback: fallback,
+                compatibility: compatibility,
+                hack: hack
+            });
+        }
+
+        return values[0];
     }
 }
 

--- a/js/locale/model-locale-resolver.js
+++ b/js/locale/model-locale-resolver.js
@@ -28,7 +28,7 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
         } = {}
     ) {
         const ripe = this.ripeProvider.ripe;
-        return ripe.localeColor(color, this.localePlugin, {
+        return this.localeModel(color, {
             brand: this.brand,
             model: this.model,
             part: part,
@@ -36,7 +36,8 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
             locale: locale,
             defaultValue: defaultValue,
             prefixes: prefixes,
-            suffixes: suffixes
+            suffixes: suffixes,
+            localeFunc: ripe.localeColor
         });
     }
 
@@ -45,26 +46,28 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
         { part = null, locale = null, defaultValue = null, prefixes = [], suffixes = [] } = {}
     ) {
         const ripe = this.ripeProvider.ripe;
-        return ripe.localeMaterial(material, this.localePlugin, {
+        return this.localeModel(material, {
             brand: this.brand,
             model: this.model,
             part: part,
             locale: locale,
             defaultValue: defaultValue,
             prefixes: prefixes,
-            suffixes: suffixes
+            suffixes: suffixes,
+            localeFunc: ripe.localeMaterial
         });
     }
 
     localePart(part, { locale = null, defaultValue = null, prefixes = [], suffixes = [] } = {}) {
         const ripe = this.ripeProvider.ripe;
-        return ripe.localePart(part, this.localePlugin, {
+        return this.localeModel(part, {
             brand: this.brand,
             model: this.model,
             locale: locale,
             defaultValue: defaultValue,
             prefixes: prefixes,
-            suffixes: suffixes
+            suffixes: suffixes,
+            localeFunc: ripe.localePart
         });
     }
 
@@ -73,22 +76,24 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
         { type = null, locale = null, defaultValue = null, prefixes = [], suffixes = [] } = {}
     ) {
         const ripe = this.ripeProvider.ripe;
-        return ripe.localeProperty(name, this.localePlugin, {
+        return this.localeModel(name, {
             brand: this.brand,
             model: this.model,
             type: type,
             locale: locale,
             defaultValue: defaultValue,
             prefixes: prefixes,
-            suffixes: suffixes
+            suffixes: suffixes,
+            localeFunc: ripe.localeProperty
         });
     }
 
-    localeModel(value, { locale = null, defaultValue = null, ...options } = {}) {
+    localeModel(value, { locale = null, defaultValue = null, localeFunc = null, ...options } = {}) {
         options = Object.assign(
             {
                 locale: locale,
-                defaultValue: defaultValue
+                defaultValue: defaultValue,
+                localeFunc: localeFunc
             },
             options
         );
@@ -113,12 +118,15 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
             prefix = "builds",
             fallback = false,
             compatibility = true,
-            hack = false
+            hack = false,
+            localeFunc = null,
+            ...options
         } = {}
     ) {
         const ripe = this.ripeProvider.ripe;
+        localeFunc = localeFunc || ripe.localeModel;
         const values = Array.isArray(value) ? value : [value];
-        const result = ripe.localeModel(value, this.localePlugin, {
+        const result = localeFunc.call(ripe, value, this.localePlugin, {
             brand: brand,
             model: model,
             locale: locale,
@@ -126,7 +134,8 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
             prefix: prefix,
             fallback: fallback,
             compatibility: compatibility,
-            hack: hack
+            hack: hack,
+            ...options
         });
 
         // if the localization was successful returns its result
@@ -146,7 +155,9 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
                 prefix: prefix,
                 fallback: fallback,
                 compatibility: compatibility,
-                hack: hack
+                hack: hack,
+                localeFunc: localeFunc,
+                ...options
             });
         }
 

--- a/js/locale/model-locale-resolver.js
+++ b/js/locale/model-locale-resolver.js
@@ -82,73 +82,12 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
         });
     }
 
-    localeModel(value, { locale = null, defaultValue = null, ...options } = {}) {
-        options = Object.assign(
-            {
-                locale: locale,
-                defaultValue: defaultValue
-            },
-            options
-        );
-        return this._toLocale(value, this.brand, this.model, options);
-    }
-
     _bind() {
         this.owner.bind("config", config => {
             const { brand, name } = config || {};
             this.brand = brand;
             this.model = name;
         });
-    }
-
-    _toLocale(
-        value,
-        brand,
-        model,
-        {
-            locale = null,
-            defaultValue = null,
-            prefix = "builds",
-            fallback = false,
-            compatibility = true,
-            hack = false
-        } = {}
-    ) {
-        const ripe = this.ripeProvider.ripe;
-        const values = Array.isArray(value) ? value : [value];
-        const result = ripe.localeModel(value, this.localePlugin, {
-            brand: brand,
-            model: model,
-            locale: locale,
-            defaultValue: defaultValue,
-            prefix: prefix,
-            fallback: fallback,
-            compatibility: compatibility,
-            hack: hack
-        });
-
-        // if the localization was successful returns its result
-        if (result !== defaultValue) return result;
-
-        // if the localization was not successful but a default
-        // was defined, then returns it
-        if (defaultValue !== null) return result;
-
-        // otherwise run the localization process again using
-        // a fallback locale as the base for localization
-        const localeFallback = this.localePlugin.getLocaleFallback();
-        if (localeFallback !== locale) {
-            return this._toLocale(values, brand, model, {
-                locale: localeFallback,
-                defaultValue: defaultValue,
-                prefix: prefix,
-                fallback: fallback,
-                compatibility: compatibility,
-                hack: hack
-            });
-        }
-
-        return values[0];
     }
 }
 

--- a/js/locale/model-locale-resolver.js
+++ b/js/locale/model-locale-resolver.js
@@ -37,7 +37,7 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
             defaultValue: defaultValue,
             prefixes: prefixes,
             suffixes: suffixes,
-            localeFunc: ripe.localeColor
+            localeFunc: (...args) => ripe.localeColor(...args)
         });
     }
 
@@ -54,7 +54,7 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
             defaultValue: defaultValue,
             prefixes: prefixes,
             suffixes: suffixes,
-            localeFunc: ripe.localeMaterial
+            localeFunc: (...args) => ripe.localeMaterial(...args)
         });
     }
 
@@ -67,7 +67,7 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
             defaultValue: defaultValue,
             prefixes: prefixes,
             suffixes: suffixes,
-            localeFunc: ripe.localePart
+            localeFunc: (...args) => ripe.localePart(...args)
         });
     }
 
@@ -84,7 +84,7 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
             defaultValue: defaultValue,
             prefixes: prefixes,
             suffixes: suffixes,
-            localeFunc: ripe.localeProperty
+            localeFunc: (...args) => ripe.localeProperty(...args)
         });
     }
 
@@ -126,7 +126,7 @@ export class ModelLocaleResolverPlugin extends RipeCommonsPlugin {
         const ripe = this.ripeProvider.ripe;
         localeFunc = localeFunc || ripe.localeModel;
         const values = Array.isArray(value) ? value : [value];
-        const result = localeFunc.call(ripe, value, this.localePlugin, {
+        const result = localeFunc(value, this.localePlugin, {
             brand: brand,
             model: model,
             locale: locale,

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dependencies": {
         "loaders.css": "^0.1.2",
         "pluginus": "^0.3.10",
-        "ripe-sdk": "^1.25.0",
+        "ripe-sdk": "^1.25.2",
         "vue": "^2.6.12",
         "vue-global-events": "^1.2.1",
         "vuex": "^3.6.2"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-twitch/issues/44 |
| Dependencies | https://github.com/ripe-tech/ripe-sdk/pull/252 |
| Decisions | Uses the newly implemented `localePart`, `localeMaterial`, `localeColor` and `localeProperty` methods of ripe-sdk to handle localization |
| Screenshot | **en_us:**<br>![imagem](https://user-images.githubusercontent.com/22588915/108517645-963f8f80-72bf-11eb-80eb-2320ebbdcbd3.png)<br><br>**pt_br:**<br>![imagem](https://user-images.githubusercontent.com/22588915/108517707-a8b9c900-72bf-11eb-89da-241d6e520829.png)<br><br>**Tests Passing:**<br>![imagem](https://user-images.githubusercontent.com/22588915/108517416-4bbe1300-72bf-11eb-835f-782e34a14327.png) |
