### PR TITLE
#768 Add yonius casting to _field method

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -23,6 +23,8 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
      * not possible to find a valid field for the provided name.
      * @param {Boolean} sequence If the returned value should be a sequence or
      * if instead the first element should be returned.
+     * @param {String} type The type of the returned value. Will cast value to
+     * desired type. Values: int, float, bool, list, tuple.
      * @returns {String} The value for the requested field name.
      */
     static _field(name, query = null, fallback = null, sequence = null, type = null) {

--- a/js/base/main.js
+++ b/js/base/main.js
@@ -25,7 +25,7 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
      * if instead the first element should be returned.
      * @returns {String} The value for the requested field name.
      */
-    static _field(name, query = null, fallback = null, sequence = null, type = undefined) {
+    static _field(name, query = null, fallback = null, sequence = null, type = null) {
         query = query || new URLSearchParams(window.location.search);
 
         const params = query.getAll(name);

--- a/js/base/main.js
+++ b/js/base/main.js
@@ -28,13 +28,13 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
     static _field(name, query = null, fallback = null, sequence = null, type = undefined) {
         query = query || new URLSearchParams(window.location.search);
 
-        const castToType = _castR(type) || (v => v);
-
         const params = query.getAll(name);
 
         if (params.length === 0) {
-            return castToType(fallback);
+            return fallback;
         }
+
+        const castToType = _castR(type) || (v => v);
 
         if (sequence === null) sequence = params.length > 1;
         return sequence ? params.map(p => castToType(p)) : castToType(params[0]);

--- a/js/base/main.js
+++ b/js/base/main.js
@@ -4,6 +4,7 @@ import Vue from "vue";
 import Vuex from "vuex";
 import GlobalEvents from "vue-global-events";
 import { Ripe } from "ripe-sdk";
+import { _castR } from "yonius";
 
 import { components, plugins, mixins, store } from "../../vue";
 import { RipeCommonsPlugin, RipeCommonsCapability } from "../abstract";
@@ -24,17 +25,19 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
      * if instead the first element should be returned.
      * @returns {String} The value for the requested field name.
      */
-    static _field(name, query = null, fallback = null, sequence = null) {
+    static _field(name, query = null, fallback = null, sequence = null, type = undefined) {
         query = query || new URLSearchParams(window.location.search);
+
+        const castToType = _castR(type) || (v => v);
 
         const params = query.getAll(name);
 
         if (params.length === 0) {
-            return fallback;
+            return castToType(fallback);
         }
 
         if (sequence === null) sequence = params.length > 1;
-        return sequence ? params : params[0];
+        return sequence ? params.map(p => castToType(p)) : castToType(params[0]);
     }
 
     async load() {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
         "ripe-sdk": "^1.25.1",
         "vue": "^2.6.12",
         "vue-global-events": "^1.2.1",
-        "vuex": "^3.6.2"
+        "vuex": "^3.6.2",
+        "yonius": "^0.7.2"
     },
     "devDependencies": {
         "@storybook/addon-knobs": "^6.1.18",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/768 |
| Decisions | Use yonius `_castR` to cast values in `_field` method as suggested in https://github.com/ripe-tech/ripe-white/pull/790#pullrequestreview-595457554 . This is to solve the problem that we're having in which is impossible to set a value to false using querystring because `Boolean("false")` and `Boolean("0")` will be translating to true. |
