### PR TITLE
fix: remove product ID from options

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -133,9 +133,9 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
                 throw new Error("No valid product ID structure");
             }
 
-            // avoid including the product ID if it's not
-            // a "real" RIPE product ID but just a
-            // ripe-commons-pluginus facade for a config
+            // avoid including the product ID if it's not a "real"
+            // RIPE product ID but just a ripe-commons-pluginus facade
+            // for a config (prefixed with xxx: and a string)
             if (!isProductId) delete this.options.product_id;
         }
 

--- a/js/base/main.js
+++ b/js/base/main.js
@@ -71,6 +71,33 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
         // initializes the app state accordingly
         await this._loadOptions();
 
+        // instantiates the RIPE object and its required plugins
+        this.restrictionsPlugin = new Ripe.plugins.RestrictionsPlugin();
+        this.syncPlugin = new Ripe.plugins.SyncPlugin();
+        this.ripe = new Ripe({ init: false });
+
+        // binds to the necessary events sent through the owner,
+        // includes the piping of event from RIPE to Vue.js
+        this._bind();
+
+        // waits for the complete of the RIPE SDK loading process
+        // so that all the necessary components are loaded, notice
+        // that both the brand, model, variant and version and unset
+        // so that these values can be set latter
+        await this.ripe.init({
+            plugins: [this.restrictionsPlugin, this.syncPlugin],
+            ...this.options,
+            brand: null,
+            model: null,
+            variant: null,
+            version: null
+        });
+
+        // loads the vue components and mixins to be used on
+        // the vue app and initializes it with the target app element
+        await this._loadVue();
+        this.app = await this._initVueApp(this.appElement);
+
         // allocates space for the object that will hold the target model
         // configuration to be applied to the ripe instance
         const config = {};
@@ -111,32 +138,6 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
             // ripe-commons-pluginus facade for a config
             if (!isProductId) delete this.options.product_id;
         }
-
-        // instantiates the RIPE object and its required plugins
-        this.restrictionsPlugin = new Ripe.plugins.RestrictionsPlugin();
-        this.syncPlugin = new Ripe.plugins.SyncPlugin();
-        this.ripe = new Ripe({ init: false });
-
-        // binds to the necessary events sent through the owner
-        this._bind();
-
-        // waits for the complete of the RIPE SDK loading process
-        // so that all the necessary components are loaded, notice
-        // that both the brand, model, variant and version so that
-        // these values are going to be set latter one
-        await this.ripe.init({
-            plugins: [this.restrictionsPlugin, this.syncPlugin],
-            ...this.options,
-            brand: null,
-            model: null,
-            variant: null,
-            version: null
-        });
-
-        // loads the vue components and mixins to be used on
-        // the vue app and starts it
-        await this._loadVue();
-        this.app = await this._initVueApp(this.appElement);
 
         // runs the setting of the model & configuration according to the currently set
         // options (initial bootstrap operation), handling critical error as expected

--- a/js/base/main.js
+++ b/js/base/main.js
@@ -71,6 +71,10 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
         // initializes the app state accordingly
         await this._loadOptions();
 
+        // builds the config object to nbe used to set the initial model
+        // this operation may mutate the currently set options object
+        const config = await this._buildConfig();
+
         // instantiates the RIPE object and its required plugins
         this.restrictionsPlugin = new Ripe.plugins.RestrictionsPlugin();
         this.syncPlugin = new Ripe.plugins.SyncPlugin();
@@ -98,10 +102,8 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
         await this._loadVue();
         this.app = await this._initVueApp(this.appElement);
 
-        // builds the config object to nbe used to set the initial model and then
         // runs the setting of the model & configuration according to the currently set
         // options (initial bootstrap operation), handling critical error as expected
-        const config = await this._buildConfig();
         this.setModelConfig(config).catch(async err => await this._handleCritical(err));
     }
 

--- a/js/base/main.js
+++ b/js/base/main.js
@@ -71,32 +71,6 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
         // initializes the app state accordingly
         await this._loadOptions();
 
-        // instantiates the RIPE object and its required plugins
-        this.restrictionsPlugin = new Ripe.plugins.RestrictionsPlugin();
-        this.syncPlugin = new Ripe.plugins.SyncPlugin();
-        this.ripe = new Ripe({ init: false });
-
-        // binds to the necessary events sent through the owner
-        this._bind();
-
-        // waits for the complete of the RIPE SDK loading process
-        // so that all the necessary components are loaded, notice
-        // that both the brand, model, variant and version so that
-        // these values are going to be set latter one
-        await this.ripe.init({
-            plugins: [this.restrictionsPlugin, this.syncPlugin],
-            ...this.options,
-            brand: null,
-            model: null,
-            variant: null,
-            version: null
-        });
-
-        // loads the vue components and mixins to be used on
-        // the vue app and starts it
-        await this._loadVue();
-        this.app = await this._initVueApp(this.appElement);
-
         // allocates space for the object that will hold the target model
         // configuration to be applied to the ripe instance
         const config = {};
@@ -131,7 +105,40 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
             } else {
                 throw new Error("No valid product ID structure");
             }
+
+            // avoid including the product ID if it's not
+            // a "real" RIPE product ID but just a
+            // ripe-commons-pluginus facade for a config
+            if (!isProductId) delete this.options.product_id;
         }
+
+        console.log(this.options);
+
+        // instantiates the RIPE object and its required plugins
+        this.restrictionsPlugin = new Ripe.plugins.RestrictionsPlugin();
+        this.syncPlugin = new Ripe.plugins.SyncPlugin();
+        this.ripe = new Ripe({ init: false });
+
+        // binds to the necessary events sent through the owner
+        this._bind();
+
+        // waits for the complete of the RIPE SDK loading process
+        // so that all the necessary components are loaded, notice
+        // that both the brand, model, variant and version so that
+        // these values are going to be set latter one
+        await this.ripe.init({
+            plugins: [this.restrictionsPlugin, this.syncPlugin],
+            ...this.options,
+            brand: null,
+            model: null,
+            variant: null,
+            version: null
+        });
+
+        // loads the vue components and mixins to be used on
+        // the vue app and starts it
+        await this._loadVue();
+        this.app = await this._initVueApp(this.appElement);
 
         // runs the setting of the model & configuration according to the currently set
         // options (initial bootstrap operation), handling critical error as expected

--- a/js/base/main.js
+++ b/js/base/main.js
@@ -112,8 +112,6 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
             if (!isProductId) delete this.options.product_id;
         }
 
-        console.log(this.options);
-
         // instantiates the RIPE object and its required plugins
         this.restrictionsPlugin = new Ripe.plugins.RestrictionsPlugin();
         this.syncPlugin = new Ripe.plugins.SyncPlugin();


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://jenkins.platforme.com/job/ripe-tests/1768/ + new product ID number validation |
| Decisions | Related to https://github.com/ripe-tech/ripe-retail/pull/263. Important part is: `if (!isProductId) delete this.options.product_id;`. The rest is just moving that "option parsing" up before options are used.  |
