### PR TITLE
fix: init loop by unsetting variant

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -197,6 +197,10 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
             config.initialsExtra = config.initials_extra;
         } else if (productId) {
             config = await this.ripe.configResolveP(productId);
+
+            // in case the variant is not defined, be
+            // explicit about it in the configuration
+            config.variant = config.variant || null;
         }
 
         // updates the currently set options with the model configuration


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/797 |
| Decisions | The product ID resolution had `variant: ""` while the SDK would normalize it to `variant: null` which would result in a config init loop. |
