### PR TITLE
#845 Add missing variant to _buildConfig

### DIFF
--- a/js/base/main.js
+++ b/js/base/main.js
@@ -482,8 +482,8 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
                 brand: this.options.brand,
                 model: this.options.model,
                 version: this.options.version || null,
-                parts: this.options.parts || {},
-                variant: this.options.variant || null
+                variant: this.options.variant || null,
+                parts: this.options.parts || {}
             });
         }
         // otherwise in case the DKU value is set in the options

--- a/js/base/main.js
+++ b/js/base/main.js
@@ -482,7 +482,8 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
                 brand: this.options.brand,
                 model: this.options.model,
                 version: this.options.version || null,
-                parts: this.options.parts || {}
+                parts: this.options.parts || {},
+                variant: this.options.variant || null
             });
         }
         // otherwise in case the DKU value is set in the options


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/825 <br> When [setModelConfig](https://github.com/ripe-tech/ripe-commons-pluginus/blob/master/js/base/main.js#L111) is called to set proper `$ripe.brand, $ripe.model, ...configs`, `ripe` will always be instantiated with a `null` variant. This is not intended. The fix is having `variant` in config coming from `this.options.variant`. This way, `ripe-white` which is already using and overriding `this.options` with a proper variant [here](https://github.com/ripe-tech/ripe-white/blob/master/js/plugins/base/main.js#L250), along with all the other options, will be able to set to the desired variant and later properly call `getPriceP` which otherwise would always have `null` variant.  |
| Dependencies | https://github.com/ripe-tech/ripe-sdk/pull/261 |
| Decisions | Add missing variant to ripe config object when doing `_buildConfig`. |
| Animated GIF | ![Peek 2021-04-27 16-27](https://user-images.githubusercontent.com/24736423/116268875-a1a6af80-a775-11eb-9443-879a1e4c63d6.gif) |
| Testing | For testing purposes, here's a core-now [price](https://ripe-core-now.platforme.com/api/config/price?brand=sergio_rossi&country=jp&currency=jpy&initials=%24empty&model=sr1_running&p=back%3Aroyal_sr%3Ablack&p=front%3Aroyal_sr%3Ablack&p=loop%3Agrosgrain_sr%3Ablack&p=plate%3Ametal_sr%3Agold24&p=shadow%3Adefault%3Adefault&p=side%3Atechnical_fabric_sr%3Ablack&p=sole%3Arubber_sr%3Ablack&p=tongue%3Aroyal_sr%3Ablack&variant=retail) that changes it's `total.price_final` when adding/removing the `variant=retail`. White's query is `?brand=sergio_rossi&model=sr1_running&variant=retail&country=jp&currency=jpy` |
