### PR TITLE
fix: avoid calling 3DB logic methods with undefined ctx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Avoid calling 3DB logic methods with undefined `ctx`
 
 ## [0.10.6] - 2021-05-04
 

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -282,7 +282,8 @@ export const Reference = {
                 this.groups = await this.$ripe.runLogicP({
                     brand: this.brand,
                     model: this.model,
-                    method: "groups"
+                    method: "groups",
+                    dataJ: { ctx: {} }
                 });
             } catch (err) {
                 // gives a default group if builds does not support remote

--- a/vue/store.js
+++ b/vue/store.js
@@ -208,7 +208,8 @@ export const store = {
                 (async () => {
                     try {
                         return await this._vm.$ripe.runLogicP({
-                            method: "groups"
+                            method: "groups",
+                            dataJ: { ctx: {} }
                         });
                     } catch {
                         return ["main"];
@@ -217,7 +218,8 @@ export const store = {
                 (async () => {
                     try {
                         const supportedCharacters = await this._vm.$ripe.runLogicP({
-                            method: "supported_characters"
+                            method: "supported_characters",
+                            dataJ: { ctx: {} }
                         });
                         return [...supportedCharacters];
                     } catch {
@@ -227,7 +229,8 @@ export const store = {
                 (async () => {
                     try {
                         return await this._vm.$ripe.runLogicP({
-                            method: "minimum_initials"
+                            method: "minimum_initials",
+                            dataJ: { ctx: {} }
                         });
                     } catch {
                         return 0;
@@ -236,7 +239,8 @@ export const store = {
                 (async () => {
                     try {
                         return await this._vm.$ripe.runLogicP({
-                            method: "maximum_initials"
+                            method: "maximum_initials",
+                            dataJ: { ctx: {} }
                         });
                     } catch {
                         return Infinity;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Triggered by https://github.com/ripe-tech/builds-static/pull/1207 |
