### PR TITLE
fix: set correct configurator size on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Set the correct size when initiating the configurator, avoiding visual glitches
 
 ## [0.12.2] - 2021-07-18
 

--- a/vue/components/organisms/configurator/configurator.vue
+++ b/vue/components/organisms/configurator/configurator.vue
@@ -197,7 +197,7 @@ export const Configurator = {
             return this.singleFrameView || this.frameChanged || this.holderTimedOut;
         },
         mergedOptions() {
-            return { ...this.options, useMasks: this.useMasks };
+            return { ...this.options, useMasks: this.useMasks, size: this.size };
         }
     },
     data: function() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Dependencies | https://github.com/ripe-tech/ripe-sdk/pull/296 |

