### PR TITLE
Initials images: fix aspect ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Wrong image ration for certain window size situations.
 
 ## [0.12.3] - 2021-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Wrong image ration for certain window size situations.
+* Wrong image aspect ratio for certain window sizes.
 
 ## [0.12.3] - 2021-07-26
 

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -34,6 +34,7 @@ body.mobile .initials-images .initials-image,
 body.tablet .initials-images .initials-image {
     height: auto;
     max-width: 600px;
+    object-fit: contain;
     width: 100%;
 }
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/871 |
| Decisions | - Add objectFit contain CSS rule to maintain original image aspect ratio. |
