### PR TITLE
Field parameters with false sequence by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Using sequence as false when extracting field values in `_field`
 
 ### Fixed
 

--- a/js/base/main.js
+++ b/js/base/main.js
@@ -28,7 +28,7 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
      * standard set of types.
      * @returns {String} The value for the requested field name.
      */
-    static _field(name, query = null, fallback = null, sequence = null, type = null) {
+    static _field(name, query = null, fallback = null, sequence = false, type = null) {
         query = query || new URLSearchParams(window.location.search);
 
         const params = query.getAll(name);
@@ -39,7 +39,7 @@ export class RipeCommonsMainPlugin extends RipeCommonsPlugin {
 
         const castToType = _castR(type) || (v => v);
 
-        if (sequence === null) sequence = params.length > 1;
+        if (sequence) sequence = params.length > 1;
         return sequence ? params.map(p => castToType(p)) : castToType(params[0]);
     }
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | `_field` is [being used](https://github.com/search?q=org%3Aripe-tech+_field&type=code) to extract URL parameter fields in RIPE White. The `sequence` arg is `null` by default which means that if we send a url including parameters like `?brand=swear&model=vyner&locale=en_us&locale=pt_br` we will translate to locale=["en_us", "pt_br"] **by default** which means trouble as most parameters are not supposed to be arrays. Visit https://ripe-white-now.platforme.com/?brand=swear&model=vyner&model=vyner as another example if we by mistake duplicate one parameter, it will translate to error. This can avoided by just changing the default sequence to false. Please check the table below to see how many multiple value parameters we have as a justification on why we should use sequence = false by default instead. |
| Decisions | - Using `sequence = false` by default |


| field name                     | sequence |
| ------------------------------ | -------- |
| state                          | ❌        |
| ctx                            | ❌        |
| context                        | ❌        |
| product_id                     | ❌        |
| brand                          | ❌        |
| model                          | ❌        |
| variant                        | ❌        |
| version                        | ❌        |
| dku                            | ❌        |
| country                        | ❌        |
| currency                       | ❌        |
| locale                         | ❌        |
| flag                           | ❌        |
| initials                       | ❌        |
| engraving                      | ❌        |
| initials_extra                 | ✅        |
| format                         | ❌        |
| background_color               | ❌        |
| guess                          | ❌        |
| guess_url                      | ❌        |
| remote_calls                   | ❌        |
| resolution                     | ❌        |
| use_bundles                    | ❌        |
| use_combinations               | ❌        |
| use_defaults                   | ❌        |
| use_diag                       | ❌        |
| use_price                      | ❌        |
| use_masks                      | ❌        |
| theme                          | ❌        |
| flags                          | ❌        |
| features                       | ✅        |
| extra_scripts                  | ✅        |
| title                          | ❌        |
| page_title                     | ❌        |
| logo                           | ❌        |
| logo_mobile                    | ❌        |
| favicon                        | ❌        |
| previous                       | ❌        |
| next                           | ❌        |
| previous_label                 | ❌        |
| next_label                     | ❌        |
| summary                        | ❌        |
| preferred_frame                | ❌        |
| tech                           | ❌        |
| technical                      | ❌        |
| gender                         | ❌        |
| genders                        | ❌        |
| reference_scale                | ❌        |
| available_scales               | ✅        |
| size_button_label              | ❌        |
| size_button_selected_label     | ❌        |
| size_modal_title               | ❌        |
| size_modal_subtitle            | ❌        |
| size_select_label              | ❌        |
| size_cancel_label              | ❌        |
| personalization_button_label   | ❌        |
| personalization_modal_title    | ❌        |
| personalization_modal_subtitle | ❌        |
| personalization_apply_label    | ❌        |
| personalization_clear_label    | ❌        |
| pickers_show_label             | ❌        |
| pickers_hide_label             | ❌        |
| details_title                  | ❌        |
| details_content                | ❌        |
| info_title                     | ❌        |
| info_subtitle                  | ❌        |
| info_content                   | ❌        |

