### PR TITLE
Resolution not being set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Resolution not being set by SDK Options or URL params
+
 ## [0.16.1] - 2021-11-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Resolution not being set by SDK Options or URL params
+* Resolution not being properly set by SDK options or URL params - [#272](https://github.com/ripe-tech/ripe-commons-pluginus/pull/272)
 
 ## [0.16.1] - 2021-11-21
 

--- a/vue/components/organisms/configurator/configurator.vue
+++ b/vue/components/organisms/configurator/configurator.vue
@@ -199,8 +199,7 @@ export const Configurator = {
         mergedOptions() {
             return {
                 ...this.options,
-                useMasks: this.useMasks === undefined ? this.options.useMasks : this.useMasks,
-                size: this.size
+                useMasks: this.useMasks === undefined ? this.options.useMasks : this.useMasks
             };
         }
     },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | The configurator isn't properly reacting to the resolution set in SDK Options <img width="1865" alt="image" src="https://user-images.githubusercontent.com/24736423/141979265-7c7715b3-4072-4fcc-a1b3-70e3faa6c378.png">  or the one received in the URL params as it should. Repro URL: https://ripe-white-now.platforme.com/?brand=swear&model=vyner&locale=en_us&tech=1&resolution=100&p=lining%3Acalf_lining%3Awhite&p=front%3Anappa%3Awhite&p=side%3Anappa%3Awhite&p=sole%3Arubber%3Awhite&p=laces%3Anylon%3Awhite&p=logo%3Ametal%3Asilver&p=hardware%3Ametal%3Asilver&p=shadow%3Adefault%3Adefault |
| Decisions | Remove wrong size merge option introduced [here](https://github.com/ripe-tech/ripe-commons-pluginus/pull/264/files#diff-8d351241fd69fae9eceac110bf648712acf2a611b46d08727f6980d6581558b3R203). `this.size` =/= `this.options.size` **they are not the same thing** - `this.size` is the width and height of the configurator and `this.options.size` is the resolution of the remote image.   |
| Animated GIF | Below |

### Before
<img width="1865" alt="image" src="https://user-images.githubusercontent.com/24736423/141980537-5d07d71c-c318-496e-a985-80771090af80.png">

### After
<img width="1865" alt="image" src="https://user-images.githubusercontent.com/24736423/141980482-6ef2178e-390c-41f0-9688-3e7fb0489c49.png">



