### PR TITLE
#943: Allow rectangular images in thumbnails and configurator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Support rectangular thumbnails - [ripe-white/#943](https://github.com/ripe-tech/ripe-white/issues/943)
 
 ### Fixed
 

--- a/vue/components/atoms/thumbnail/thumbnail.vue
+++ b/vue/components/atoms/thumbnail/thumbnail.vue
@@ -47,7 +47,7 @@ body.desktop .thumbnail:first-child {
 body.tablet .thumbnail,
 body.mobile .thumbnail {
     display: inline-block;
-    height: 50px;
+    height: auto;
     margin: 0px auto 0px 7px;
     width: 50px;
 }

--- a/vue/components/organisms/configurator/configurator.vue
+++ b/vue/components/organisms/configurator/configurator.vue
@@ -160,6 +160,22 @@ export const Configurator = {
             default: null
         },
         /**
+         * The width of the configurator in pixels, that allows support
+         * for non-square images.
+         */
+        width: {
+            type: Number,
+            default: null
+        },
+        /**
+         * The height of the configurator in pixels, that allows support
+         * for non-square images.
+         */
+        height: {
+            type: Number,
+            default: null
+        },
+        /**
          * The time accepted for the holder to appear on the display
          * without any interaction of the user.
          */
@@ -290,7 +306,7 @@ export const Configurator = {
             // triggers the resize operation, as some pending resize operation
             // may have been pilling up during the loading operation, during which
             // is not possible to trigger resize operations
-            this.resize(this.size);
+            this.resize(this.size, this.width, this.height);
 
             // updates the current frame in the store, this information can be used
             // by listener to update their internal state
@@ -367,7 +383,7 @@ export const Configurator = {
             }
         });
 
-        this.resize(this.size);
+        this.resize(this.size, this.width, this.height);
     },
     watch: {
         frame(value) {
@@ -414,6 +430,16 @@ export const Configurator = {
             // in the configurator, to change the viewport accordingly
             this.resize(size);
         },
+        width(width) {
+            // reacts to the new width by triggering the resize operation
+            // in the configurator, to change the viewport accordingly
+            this.resize(null, width, this.height);
+        },
+        height(height) {
+            // reacts to the new height by triggering the resize operation
+            // in the configurator, to change the viewport accordingly
+            this.resize(null, this.width, height);
+        },
         useMasks() {
             if (!this.configurator) return;
             if (this.useMasks) this.configurator.enableMasks();
@@ -431,11 +457,11 @@ export const Configurator = {
          * Re-sizes the configurator according to the current
          * available container size (defined by parent).
          */
-        resize(size) {
+        resize(size, width, height) {
             // in case the size is invalid or no valid configurator
             // is available then returns the control flow as nothing
             // can be done under such conditions
-            if (!size || !this.configurator) return;
+            if (!(size || (width && height)) || !this.configurator) return;
 
             // in case the configurator is currently under loading
             // then ignores the resize request as this would trigger
@@ -444,7 +470,7 @@ export const Configurator = {
 
             // runs the underlying resize operation using the RIPE
             // SDK configurator element method
-            this.configurator.resize(size);
+            this.configurator.resize(size, width, height);
         }
     },
     destroyed: async function() {

--- a/vue/components/organisms/configurator/configurator.vue
+++ b/vue/components/organisms/configurator/configurator.vue
@@ -457,7 +457,7 @@ export const Configurator = {
          * Re-sizes the configurator according to the current
          * available container size (defined by parent).
          */
-        resize(size, width, height) {
+        resize(size = null, width = null, height = null) {
             // in case the size is invalid or no valid configurator
             // is available then returns the control flow as nothing
             // can be done under such conditions


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/943 |
| Dependencies | https://github.com/ripe-tech/ripe-sdk/pull/340 |
| Decisions | - Support rectangular thumbnails<br>- Support width and height resize in configurator |
| Animated GIF | -- |

**Test: use context `saint_laurent_hoodie`** 

https://user-images.githubusercontent.com/25725586/148554763-27ddc8f5-3e3d-4c3e-bc27-327445d1ad14.mp4


