### PR TITLE
#948: Do not emit load:images event if frame is outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Only emit `load:images` event  in `initials-images` if the image loaded is up to date with the frame - [ripe-white/#948](https://github.com/ripe-tech/ripe-white/issues/948)
 
 ### Fixed
 

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -272,10 +272,15 @@ export const InitialsImages = {
             // so sends an event
             if (!this.groups.every(group => Object.keys(this.srcs).includes(group))) return;
 
-            // does not send load images if the frame of the image
-            // loaded is outdated
+            // incase the frame that was loaded is not longer the
+            // latest one ignores the load operation, retuning the
+            // control flow immediately
             const queryParams = this.$ripe._unpackQuery(src);
             if (this.frame && queryParams.frame !== this.frame) return;
+
+            // triggers the load images operation indicating that
+            // all of the images for the current configuration
+            // have been loaded
             this.$emit("load:images");
         }
     }

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -271,6 +271,11 @@ export const InitialsImages = {
             // verifies if all images were loaded and if
             // so sends an event
             if (!this.groups.every(group => Object.keys(this.srcs).includes(group))) return;
+
+            // does not send load images if the frame of the image
+            // loaded is outdated
+            const queryParams = this.$ripe._unpackQuery(src);
+            if (this.frame && queryParams.frame !== this.frame) return;
             this.$emit("load:images");
         }
     }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/948 |
| Dependencies | -- |
| Decisions | - Only sends loaded event if the image loaded is the same as the one we want to show. This is necessary because the frame might change while an update is being made in the previous frame and we do not want to show/load that. |
| Animated GIF |![white-improvements-initials](https://user-images.githubusercontent.com/25725586/149177498-dfc55bff-fe94-478f-ae4e-bd59d7112e33.gif) |
