### PR TITLE
#954: Set initial size, width and height of the configurator on bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Set initial `size`, `width` and `height` on configurator bind so that the correct initial dimensions can be applied - [ripe-white/#954](https://github.com/ripe-tech/ripe-white/issues/954)
 
 ## [0.20.1] - 2022-01-18
 

--- a/vue/components/organisms/configurator/configurator.vue
+++ b/vue/components/organisms/configurator/configurator.vue
@@ -215,6 +215,9 @@ export const Configurator = {
         mergedOptions() {
             return {
                 ...this.options,
+                size: this.size,
+                width: this.width,
+                height: this.height,
                 useMasks: this.useMasks === undefined ? this.options.useMasks : this.useMasks
             };
         }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/954 |
| Dependencies | -- |
| Decisions | - The initial dimensions of the configurator were not being passed, so it was defaulting to the 1000x1000 that are the default values of `width` and `height` of the configurator. If we removed that, it would default to the maximum width of the `.content` (1500px). It was necessary to pass this initials dimensions (which we already have calculated) so that they can be applied while the images load. |
| Animated GIF | ![white-scroll-bug fix](https://user-images.githubusercontent.com/25725586/149960340-5817a438-bbc4-4c67-aeb4-63a850edbabd.gif)![white-scroll-bug-fix-small](https://user-images.githubusercontent.com/25725586/149960382-db1893b5-4adf-4b72-9dd6-ce2d062f144e.gif)|
