### PR TITLE
#962: Fix drag indicator in configurator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Fix logic to show drag indicator for configurator - [ripe-white/#962](https://github.com/ripe-tech/ripe-white/issues/962)
 
 ## [0.20.3] - 2022-01-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Bumped dependencies and upgrade webpack configuration
+* Added prop that enables/disabled drag indicator for configurator - [ripe-white/#962](https://github.com/ripe-tech/ripe-white/issues/962)
 
 ### Fixed
 

--- a/vue/components/organisms/configurator/configurator.vue
+++ b/vue/components/organisms/configurator/configurator.vue
@@ -176,6 +176,14 @@ export const Configurator = {
             default: null
         },
         /**
+         * If enabled shows the holder (drag indicator) under the configurator
+         * images during a time interval or until the user interacts with it.
+         */
+        holder: {
+            type: Boolean,
+            default: true
+        },
+        /**
          * The time accepted for the holder to appear on the display
          * without any interaction of the user.
          */
@@ -190,14 +198,6 @@ export const Configurator = {
         useMasks: {
             type: Boolean,
             default: undefined
-        },
-        /**
-         * If enabled shows a drag indicator under the configurator images
-         * during a time interval or until the user interacts with it.
-         */
-        showDragIndicator: {
-            type: Boolean,
-            default: true
         },
         /**
          * Callback function to be called when a configurator related
@@ -219,7 +219,7 @@ export const Configurator = {
         },
         hideHolder() {
             return (
-                !this.showDragIndicator ||
+                !this.holder ||
                 this.singleFrameView ||
                 this.frameChanged ||
                 this.holderTimedOut

--- a/vue/components/organisms/configurator/configurator.vue
+++ b/vue/components/organisms/configurator/configurator.vue
@@ -273,9 +273,10 @@ export const Configurator = {
         );
 
         this.configurator.bind("changed_frame", frame => {
-            // sets the frame changed flag and then updates
-            // the frame key to the new one (internal copy)
-            this.frameChanged = true;
+            // sets the frame changed flag only if there was a
+            // previous frame set and then updates the frame
+            // key to the new one (internal copy)
+            this.frameChanged = Boolean(this.frameData);
             this.frameData = frame;
 
             // updates the value of the single frame view

--- a/vue/components/organisms/configurator/configurator.vue
+++ b/vue/components/organisms/configurator/configurator.vue
@@ -192,6 +192,14 @@ export const Configurator = {
             default: undefined
         },
         /**
+         * If enabled shows a drag indicator under the configurator images
+         * during a time interval or until the user interacts with it.
+         */
+        showDragIndicator: {
+            type: Boolean,
+            default: true
+        },
+        /**
          * Callback function to be called when a configurator related
          * error is thrown, for some operations (eg: while changing frame).
          */
@@ -210,7 +218,12 @@ export const Configurator = {
             return getComputedStyle(this.configurator.element).display !== "none";
         },
         hideHolder() {
-            return this.singleFrameView || this.frameChanged || this.holderTimedOut;
+            return (
+                !this.showDragIndicator ||
+                this.singleFrameView ||
+                this.frameChanged ||
+                this.holderTimedOut
+            );
         },
         mergedOptions() {
             return {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/962 |
| Dependencies | -- |
| Decisions | - Only set flag `frameChanged` as `true` when there was a frame previously set, or else it will be `true` once the frame loads for the first time - it should show the drag indicator while that happens<br>- Add prop `showDragIndicator` that enables/disables the drag indicator. |
| Animated GIF | -- |

https://user-images.githubusercontent.com/25725586/153576523-9942724c-10fe-4e97-b589-ce999b2d870f.mp4
