### PR TITLE
fix: revert to node-fetch 2 and added workaround

### DIFF
--- a/test/locale/model-locale-resolver.js
+++ b/test/locale/model-locale-resolver.js
@@ -1,65 +1,62 @@
-(async function() {
-    const loadFetch = require("../setup").loadFetch;
-    await loadFetch();
+require("../setup");
 
-    const assert = require("assert");
-    const pluginus = require("pluginus");
-    const ripeCommons = require("../..");
-    const ripe = require("ripe-sdk").ripe;
+const assert = require("assert");
+const pluginus = require("pluginus");
+const ripeCommons = require("../..");
+const ripe = require("ripe-sdk").ripe;
 
-    class RipeProviderPlugin extends ripeCommons.RipeCommonsPlugin {
-        async load() {
-            await super.load();
-            this.ripe = new ripe.Ripe({ init: false });
-        }
-
-        async unload() {
-            await super.unload();
-            this.ripe = null;
-        }
-
-        getCapabilities() {
-            return [ripeCommons.RipeCommonsCapability.new("ripe-provider")];
-        }
+class RipeProviderPlugin extends ripeCommons.RipeCommonsPlugin {
+    async load() {
+        await super.load();
+        this.ripe = new ripe.Ripe({ init: false });
     }
 
-    describe("ModelLocaleResolverPlugin", function() {
-        before(async function() {
-            console.log("step call");
-            await setup();
-            console.log(global.fetch);
-            const manager = new pluginus.PluginManager();
-            ripeCommons.registerPlugins(manager);
-            RipeProviderPlugin.register(manager);
+    async unload() {
+        await super.unload();
+        this.ripe = null;
+    }
 
-            const localePlugin = await manager.getPluginByName("LocalePlugin");
-            localePlugin.setLocale("en_us");
-            localePlugin.setLocaleMap({
-                en_us: {
-                    "builds.swear.colors.red": "Red",
-                    "builds.swear.colors.rubber.red": "Rubber Red",
-                    "builds.swear.colors.sole.rubber.red": "Sole Rubber Red"
-                }
-            });
+    getCapabilities() {
+        return [ripeCommons.RipeCommonsCapability.new("ripe-provider")];
+    }
+}
 
-            this.manager = manager;
+describe("ModelLocaleResolverPlugin", function() {
+    before(async function() {
+        console.log("step call");
+        await setup();
+        console.log(global.fetch);
+        const manager = new pluginus.PluginManager();
+        ripeCommons.registerPlugins(manager);
+        RipeProviderPlugin.register(manager);
+
+        const localePlugin = await manager.getPluginByName("LocalePlugin");
+        localePlugin.setLocale("en_us");
+        localePlugin.setLocaleMap({
+            en_us: {
+                "builds.swear.colors.red": "Red",
+                "builds.swear.colors.rubber.red": "Rubber Red",
+                "builds.swear.colors.sole.rubber.red": "Sole Rubber Red"
+            }
         });
 
-        describe("#localeColor()", function() {
-            it("should make a simple color translation", async () => {
-                const plugin = await this.ctx.manager.getPluginByName("ModelLocaleResolverPlugin");
-                plugin.brand = "swear";
-                plugin.model = "vyner";
-                assert.strictEqual("Red", plugin.localeColor("red"));
-                assert.strictEqual(
-                    plugin.localeColor("red", { part: "front", material: "rubber" }),
-                    "Rubber Red"
-                );
-                assert.strictEqual(
-                    plugin.localeColor("red", { part: "sole", material: "rubber" }),
-                    "Sole Rubber Red"
-                );
-            });
+        this.manager = manager;
+    });
+
+    describe("#localeColor()", function() {
+        it("should make a simple color translation", async () => {
+            const plugin = await this.ctx.manager.getPluginByName("ModelLocaleResolverPlugin");
+            plugin.brand = "swear";
+            plugin.model = "vyner";
+            assert.strictEqual("Red", plugin.localeColor("red"));
+            assert.strictEqual(
+                plugin.localeColor("red", { part: "front", material: "rubber" }),
+                "Rubber Red"
+            );
+            assert.strictEqual(
+                plugin.localeColor("red", { part: "sole", material: "rubber" }),
+                "Sole Rubber Red"
+            );
         });
     });
-})();
+});

--- a/test/locale/model-locale-resolver.js
+++ b/test/locale/model-locale-resolver.js
@@ -23,7 +23,6 @@ class RipeProviderPlugin extends ripeCommons.RipeCommonsPlugin {
 
 describe("ModelLocaleResolverPlugin", function() {
     before(async function() {
-        await setup();
         const manager = new pluginus.PluginManager();
         ripeCommons.registerPlugins(manager);
         RipeProviderPlugin.register(manager);

--- a/test/locale/model-locale-resolver.js
+++ b/test/locale/model-locale-resolver.js
@@ -23,9 +23,7 @@ class RipeProviderPlugin extends ripeCommons.RipeCommonsPlugin {
 
 describe("ModelLocaleResolverPlugin", function() {
     before(async function() {
-        console.log("step call");
         await setup();
-        console.log(global.fetch);
         const manager = new pluginus.PluginManager();
         ripeCommons.registerPlugins(manager);
         RipeProviderPlugin.register(manager);

--- a/test/setup.js
+++ b/test/setup.js
@@ -2,4 +2,8 @@ require("core-js");
 require("regenerator-runtime/runtime");
 require("jsdom-global")(undefined, { url: "https://mock.ripe-commons-pluginus.platforme.com/" });
 global.fetch = require("node-fetch");
+
+// workaround for 'self' not being populated with
+// the fetch function
+global.self = { fetch: fetch };
 global.__webpack_require__ = require;

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,15 +1,5 @@
 require("core-js");
 require("regenerator-runtime/runtime");
 require("jsdom-global")(undefined, { url: "https://mock.ripe-commons-pluginus.platforme.com/" });
-
+global.fetch = require("node-fetch");
 global.__webpack_require__ = require;
-
-module.exports = {
-    loadFetch: async () => {
-        // node-fetch uses ESM with an async import and so we need to patch
-        // the current import operation to make it compatible with the new
-        // async ESM driven approach
-        const fetchPromise = import("node-fetch").then(mod => mod.default);
-        global.fetch = (...args) => fetchPromise.then(fetch => fetch(...args));
-    }
-};


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Revert node-fetch, related to https://github.com/ripe-tech/ripe-white/pull/969 |
| Dependencies |  |
| Decisions | - The problem was not in using node-fetch with the async import, it was in `self` not being populated with `fetch`. I browsed several repositories, I could not find any situation where something like this happened. I found a workaround, but I still don't know what dependency caused this. |
| Animated GIF | -- |
