### PR TITLE
fix: configurator flickering on resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Revert `node-fetch` bump back to @2
+* Remove double update in configurator that caused flickering on resize
 
 ## [0.21.0] - 2022-02-15
 

--- a/vue/components/organisms/configurator/configurator.vue
+++ b/vue/components/organisms/configurator/configurator.vue
@@ -218,19 +218,11 @@ export const Configurator = {
             return getComputedStyle(this.configurator.element).display !== "none";
         },
         hideHolder() {
-            return (
-                !this.holder ||
-                this.singleFrameView ||
-                this.frameChanged ||
-                this.holderTimedOut
-            );
+            return !this.holder || this.singleFrameView || this.frameChanged || this.holderTimedOut;
         },
         mergedOptions() {
             return {
                 ...this.options,
-                size: this.size,
-                width: this.width,
-                height: this.height,
                 useMasks: this.useMasks === undefined ? this.options.useMasks : this.useMasks
             };
         }
@@ -280,10 +272,12 @@ export const Configurator = {
             this.holderTimedOut = true;
         }, this.timeoutHolder);
 
-        this.configurator = this.ripeInstance.bindConfigurator(
-            this.$refs.configurator,
-            this.mergedOptions
-        );
+        this.configurator = this.ripeInstance.bindConfigurator(this.$refs.configurator, {
+            ...this.mergedOptions,
+            size: this.size,
+            width: this.width,
+            height: this.height
+        });
 
         this.configurator.bind("changed_frame", frame => {
             // sets the frame changed flag only if there was a


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Problem found by @joamag  |
| Dependencies | -- |
| Decisions | - There were 2 updates being made to the configurator-prc due to the fact that `size`, `width` and `height` being present in `mergeOptions`, which triggered an `updateOptions` to configurator in addition to the resize being made to the configurator. |
| Animated GIF | -- |

https://user-images.githubusercontent.com/25725586/154293461-5698e439-2cdc-45f9-8b51-dd1e7d35be28.mp4

