### PR TITLE
feat: added getter `getSizeState` to the store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Receive `openExternally` prop on the `personalization` component - [ripe-white/#963](https://github.com/ripe-tech/ripe-white/issues/963)
+* Added getter `getSizeState` to the store, required by the `size` component
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     },
     "devDependencies": {
         "@babel/core": "^7.17.2",
+        "@babel/eslint-parser": "^7.17.0",
         "@babel/plugin-transform-runtime": "^7.17.0",
         "@babel/preset-env": "^7.16.11",
         "@babel/runtime": "^7.17.2",

--- a/vue/store.js
+++ b/vue/store.js
@@ -36,6 +36,9 @@ export const store = {
          * are available (eg: only one size available).
          */
         sizeActive: null,
+        gender: null,
+        scale: null,
+        nativeSize: null,
         currentFrame: null,
         error: null,
         hasCustomization: false,
@@ -146,6 +149,15 @@ export const store = {
         },
         sizeActive(state, value) {
             state.sizeActive = value;
+        },
+        gender(state, gender) {
+            state.gender = gender;
+        },
+        scale(state, scale) {
+            state.scale = scale;
+        },
+        nativeSize(state, nativeSize) {
+            state.nativeSize = nativeSize;
         },
         currency(state, currency) {
             state.currency = currency;
@@ -279,12 +291,8 @@ export const store = {
             try {
                 // obtains the remote data and updates the local store information
                 // to reflect the remote information
-                const [
-                    groups,
-                    supportedCharacters,
-                    minimumCharacters,
-                    maximumCharacters
-                ] = await promise;
+                const [groups, supportedCharacters, minimumCharacters, maximumCharacters] =
+                    await promise;
                 commit("initialsGroups", groups);
                 commit("initialsSupportedCharacters", supportedCharacters);
                 commit("initialsMinimumCharacters", Number(minimumCharacters));
@@ -353,7 +361,7 @@ export const store = {
         getSizeState: state => () => ({
             gender: state.gender,
             scale: state.scale,
-            size: parseInt(state.nativeSize)
+            size: state.nativeSize
         }),
         priceCurrency: state =>
             state.price && state.price.total ? state.price.total.currency : null,

--- a/vue/store.js
+++ b/vue/store.js
@@ -279,12 +279,8 @@ export const store = {
             try {
                 // obtains the remote data and updates the local store information
                 // to reflect the remote information
-                const [
-                    groups,
-                    supportedCharacters,
-                    minimumCharacters,
-                    maximumCharacters
-                ] = await promise;
+                const [groups, supportedCharacters, minimumCharacters, maximumCharacters] =
+                    await promise;
                 commit("initialsGroups", groups);
                 commit("initialsSupportedCharacters", supportedCharacters);
                 commit("initialsMinimumCharacters", Number(minimumCharacters));
@@ -350,6 +346,11 @@ export const store = {
         getTheme: state => () => state.theme,
         getRipeOptions: state => () => state.ripeOptions,
         getRipeState: state => () => state.ripeState,
+        getSizeState: state => () => ({
+            gender: state.gender,
+            scale: state.scale,
+            size: parseInt(state.nativeSize)
+        }),
         priceCurrency: state =>
             state.price && state.price.total ? state.price.total.currency : null,
         priceFinal: state =>

--- a/vue/store.js
+++ b/vue/store.js
@@ -279,8 +279,12 @@ export const store = {
             try {
                 // obtains the remote data and updates the local store information
                 // to reflect the remote information
-                const [groups, supportedCharacters, minimumCharacters, maximumCharacters] =
-                    await promise;
+                const [
+                    groups,
+                    supportedCharacters,
+                    minimumCharacters,
+                    maximumCharacters
+                ] = await promise;
                 commit("initialsGroups", groups);
                 commit("initialsSupportedCharacters", supportedCharacters);
                 commit("initialsMinimumCharacters", Number(minimumCharacters));


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Bug found in retail, where it said it could not access store getter `getSizeState` |
| Dependencies | |
| Decisions | - `Size` component uses `getSizeState` getter from the store - https://github.com/ripe-tech/ripe-commons-pluginus/blob/545d77bd62ea14f6dc663522c46a2fd0ce79584e/vue/components/organisms/size/size.vue#L186 - however this getter is only available in the `RIPE White` store and not in the common store, which makes an error when running in `RIPE Retail`.<br><br>- Will require backport to `RIPE White`, since the getter will have to be removed from there |
| Animated GIF | -- |
