### PR TITLE
#971 Features: reacting to open-externally for base plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Reacting to open externally feature store value - [ripe-white/#971](https://github.com/ripe-tech/ripe-white/issues/971)
+*
 
 ### Fixed
 
-*
+* Reacting to `open-externally` feature for base plugins - [ripe-white/#971](https://github.com/ripe-tech/ripe-white/issues/971)
 
 ## [0.22.0] - 2022-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add open externally as a feature - [ripe-white/#971](https://github.com/ripe-tech/ripe-white/issues/971)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Add open externally as a feature - [ripe-white/#971](https://github.com/ripe-tech/ripe-white/issues/971)
+*
 
 ### Changed
 
-*
+* Reacting to open externally feature store value - [ripe-white/#971](https://github.com/ripe-tech/ripe-white/issues/971)
 
 ### Fixed
 

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -116,6 +116,10 @@ export const Reference = {
         tabProperties: {
             type: Array,
             default: () => ["font", "font_size", "style", "position", "color"]
+        },
+        openExternally: {
+            type: Boolean,
+            default: false
         }
     },
     data: function() {
@@ -156,9 +160,6 @@ export const Reference = {
         },
         configMeta() {
             return this.$store.state.config.meta || {};
-        },
-        openExternally() {
-            return this.$store.state.features["open-externally"];
         },
         /**
          * The radius of the border for the image that is going to be used in

--- a/vue/components/forms/personalization-form/reference.vue
+++ b/vue/components/forms/personalization-form/reference.vue
@@ -6,6 +6,7 @@
             v-bind:groups="groups"
             v-bind:get-context="__getContext"
             v-bind:image-height="imageHeight"
+            v-bind:open-externally="openExternally"
             v-bind:image-border-radius="imageBorderRadius"
         />
         <div class="form">
@@ -155,6 +156,9 @@ export const Reference = {
         },
         configMeta() {
             return this.$store.state.config.meta || {};
+        },
+        openExternally() {
+            return this.$store.state.features["open-externally"];
         },
         /**
          * The radius of the border for the image that is going to be used in


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/971  |
| Decisions | - Reacting to `$store.state.features` value for "open-externally" feature. |
