### PR TITLE
#978: Initials images minimum height and undefined width/height support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Added `minimumHeight` to `initials-images` so that it can be controlled instead of the default `600` - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)
+* Added `minHeight` to `initials-images` so that it can be controlled instead of the default `600` - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)
 * Support for undefined width and height for initials image's SDK `bindImage` - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Added `minimumHeight` to `initials-images` so that it can be controlled instead of the default `600` - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)
+* Support for undefined width and height for initials image's SDK `bindImage` - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)
 
 ### Changed
 

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -148,6 +148,13 @@ export const InitialsImages = {
             default: null
         },
         /**
+         * If enabled sets a minimum width for each image.
+         */
+        minWidth: {
+            type: Number,
+            default: 600
+        },
+        /**
          * If enabled sets a minimum height for each image.
          */
         minHeight: {
@@ -228,6 +235,7 @@ export const InitialsImages = {
             if (this.imageHeight) base["max-height"] = `${this.imageHeight}px`;
             if (this.imageBorderRadius) base["border-radius"] = `${this.imageBorderRadius}`;
             if (this.imageObjectFit) base["object-fit"] = this.imageObjectFit;
+            if (this.minWidth) base.width = base.width ? base.width : `${this.minWidth}px`;
             if (this.minHeight) base.height = base.height ? base.height : `${this.minHeight}px`;
             return base;
         }

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -223,9 +223,9 @@ export const InitialsImages = {
     computed: {
         style() {
             const base = {};
-            // if (this.containerHeight || this.height) base.height = `${this.containerHeight || this.height}px`;
-            // if (this.containerWidth || this.width) base.width = `${this.containerWidth || this.width}px`;
-            // if (this.imageHeight) base["max-height"] = `${this.imageHeight}px`;
+            if (this.containerHeight || this.height) base.height = `${this.containerHeight || this.height}px`;
+            if (this.containerWidth || this.width) base.width = `${this.containerWidth || this.width}px`;
+            if (this.imageHeight) base["max-height"] = `${this.imageHeight}px`;
             if (this.imageBorderRadius) base["border-radius"] = `${this.imageBorderRadius}`;
             if (this.imageObjectFit) base["object-fit"] = this.imageObjectFit;
             return base;

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -141,6 +141,13 @@ export const InitialsImages = {
             default: null
         },
         /**
+         * If enabled sets a minimum height for each image.
+         */
+        minHeight: {
+            type: Number,
+            default: 600
+        },
+        /**
          * If enabled uses pixel ratio in image.
          */
         usePixelRatio: {
@@ -160,13 +167,6 @@ export const InitialsImages = {
         openExternally: {
             type: Boolean,
             default: false
-        },
-        /**
-         * If enabled sets a minimum height for each image.
-         */
-        minHeight: {
-            type: Number,
-            default: 600
         }
     },
     data: function() {

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -113,6 +113,13 @@ export const InitialsImages = {
             default: null
         },
         /**
+         * The max width of each image.
+         */
+        imageWidth: {
+            type: Number,
+            default: null
+        },
+        /**
          * The max height of each image.
          */
         imageHeight: {
@@ -215,12 +222,13 @@ export const InitialsImages = {
     computed: {
         style() {
             const base = {};
-            if (this.height) base.height = `${this.height}px`;
             if (this.width) base.width = `${this.width}px`;
+            if (this.height) base.height = `${this.height}px`;
+            if (this.imageWidth) base["max-width"] = `${this.imageWidth}px`;
             if (this.imageHeight) base["max-height"] = `${this.imageHeight}px`;
             if (this.imageBorderRadius) base["border-radius"] = `${this.imageBorderRadius}`;
             if (this.imageObjectFit) base["object-fit"] = this.imageObjectFit;
-            if (!base.height && this.minHeight) base.height = `${this.minHeight}px`;
+            if (this.minHeight) base.height = base.height ? base.height : `${this.minHeight}px`;
             return base;
         }
     },

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -21,7 +21,7 @@
 }
 
 .initials-images .initials-image {
-    height: 600px;
+    /* height: 600px; */
     user-select: none;
     width: auto;
 }
@@ -223,9 +223,9 @@ export const InitialsImages = {
     computed: {
         style() {
             const base = {};
-            if (this.height) base.height = `${this.containerHeight || this.height}px`;
-            if (this.width) base.width = `${this.containerWidth || this.width}px`;
-            if (this.imageHeight) base["max-height"] = `${this.imageHeight}px`;
+            // if (this.containerHeight || this.height) base.height = `${this.containerHeight || this.height}px`;
+            // if (this.containerWidth || this.width) base.width = `${this.containerWidth || this.width}px`;
+            // if (this.imageHeight) base["max-height"] = `${this.imageHeight}px`;
             if (this.imageBorderRadius) base["border-radius"] = `${this.imageBorderRadius}`;
             if (this.imageObjectFit) base["object-fit"] = this.imageObjectFit;
             return base;
@@ -245,8 +245,8 @@ export const InitialsImages = {
                     initialsViewport: this.viewport,
                     getInitialsContext: this.getContext,
                     frame: this.frame,
-                    width: parseInt(this.width),
-                    height: parseInt(this.height),
+                    width: this.width ? parseInt(this.width) : undefined,
+                    height: this.height ? parseInt(this.height) : undefined,
                     usePixelRatio: this.usePixelRatio
                 });
                 this.initialsImages.push(image);

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -141,20 +141,6 @@ export const InitialsImages = {
             default: null
         },
         /**
-         * The width of each image in the DOM.
-         */
-        containerWidth: {
-            type: Number,
-            default: null
-        },
-        /**
-         * The height of each image in the DOM.
-         */
-        containerHeight: {
-            type: Number,
-            default: null
-        },
-        /**
          * If enabled uses pixel ratio in image.
          */
         usePixelRatio: {
@@ -229,8 +215,8 @@ export const InitialsImages = {
     computed: {
         style() {
             const base = {};
-            if (this.containerHeight || this.height) base.height = `${this.containerHeight || this.height}px`;
-            if (this.containerWidth || this.width) base.width = `${this.containerWidth || this.width}px`;
+            if (this.height) base.height = `${this.height}px`;
+            if (this.width) base.width = `${this.width}px`;
             if (this.imageHeight) base["max-height"] = `${this.imageHeight}px`;
             if (this.imageBorderRadius) base["border-radius"] = `${this.imageBorderRadius}`;
             if (this.imageObjectFit) base["object-fit"] = this.imageObjectFit;

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -164,7 +164,7 @@ export const InitialsImages = {
         /**
          * If enabled sets a minimum height for each image.
          */
-        minimumHeight: {
+        minHeight: {
             type: Number,
             default: 600
         }
@@ -220,7 +220,7 @@ export const InitialsImages = {
             if (this.imageHeight) base["max-height"] = `${this.imageHeight}px`;
             if (this.imageBorderRadius) base["border-radius"] = `${this.imageBorderRadius}`;
             if (this.imageObjectFit) base["object-fit"] = this.imageObjectFit;
-            if (!base.height && this.minimumHeight) base.height = `${this.minimumHeight}px`;
+            if (!base.height && this.minHeight) base.height = `${this.minHeight}px`;
             return base;
         }
     },

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -21,7 +21,6 @@
 }
 
 .initials-images .initials-image {
-    /* height: 600px; */
     user-select: none;
     width: auto;
 }
@@ -175,6 +174,13 @@ export const InitialsImages = {
         openExternally: {
             type: Boolean,
             default: false
+        },
+        /**
+         * If enabled sets a minimum height for each image.
+         */
+        minimumHeight: {
+            type: Number,
+            default: 600
         }
     },
     data: function() {
@@ -228,6 +234,7 @@ export const InitialsImages = {
             if (this.imageHeight) base["max-height"] = `${this.imageHeight}px`;
             if (this.imageBorderRadius) base["border-radius"] = `${this.imageBorderRadius}`;
             if (this.imageObjectFit) base["object-fit"] = this.imageObjectFit;
+            if (!base.height && this.minimumHeight) base.height = `${this.minimumHeight}px`;
             return base;
         }
     },

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -142,6 +142,20 @@ export const InitialsImages = {
             default: null
         },
         /**
+         * The width of each image in the DOM.
+         */
+        containerWidth: {
+            type: Number,
+            default: null
+        },
+        /**
+         * The height of each image in the DOM.
+         */
+        containerHeight: {
+            type: Number,
+            default: null
+        },
+        /**
          * If enabled uses pixel ratio in image.
          */
         usePixelRatio: {
@@ -209,8 +223,8 @@ export const InitialsImages = {
     computed: {
         style() {
             const base = {};
-            if (this.height) base.height = `${this.height}px`;
-            if (this.width) base.width = `${this.width}px`;
+            if (this.height) base.height = `${this.containerHeight || this.height}px`;
+            if (this.width) base.width = `${this.containerWidth || this.width}px`;
             if (this.imageHeight) base["max-height"] = `${this.imageHeight}px`;
             if (this.imageBorderRadius) base["border-radius"] = `${this.imageBorderRadius}`;
             if (this.imageObjectFit) base["object-fit"] = this.imageObjectFit;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/978 |
| Dependencies | -- |
| Decisions | - Added `minimumHeight` to `initials-images` so that it can be controlled instead of the default `600` - required for showing images bigger than 600px, which we want in the configurator container in white, while maitaining backward compatibility with existing plugins that make use of this, like emilio_pucci <br>- Support for undefined width and height for initials image's SDK `bindImage` - required since we want the resize of the image to be made by compose to maintain the correct aspect ratio. |
| Animated GIF | ![personalization-only-dummy](https://user-images.githubusercontent.com/25725586/157260535-2e448d4a-310f-4b1e-bb50-a5620bdc1ec0.gif)![personalization-only-ysl](https://user-images.githubusercontent.com/25725586/157260573-68fc23c5-d98d-40cf-95b5-6650cc8f7f7a.gif)![personalization-only-mobile](https://user-images.githubusercontent.com/25725586/157260580-c7e45116-b408-4d51-9422-25d6c27bf68d.gif)|
