### PR TITLE
version: 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+
+### Fixed
+
+*
+
+## [0.23.0] - 2022-03-10
+
+### Added
+
 * Added `minHeight` to `initials-images` so that it can be controlled instead of the default `600` - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)
 * Support for undefined width and height for initials image's SDK `bindImage` - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-commons-pluginus",
-    "version": "0.22.0",
+    "version": "0.23.0",
     "description": "RIPE Commons Pluginus",
     "keywords": [
         "commons",


### PR DESCRIPTION
### Added

* Added `minHeight` to `initials-images` so that it can be controlled instead of the default `600` - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)
* Support for undefined width and height for initials image's SDK `bindImage` - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)

### Changed

* Bumped dependencies

### Fixed

* Reacting to `open-externally` feature for base plugins - [ripe-white/#971](https://github.com/ripe-tech/ripe-white/issues/971)