### PR TITLE
fix: remove default value of `minWidth` in initials-images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Remove default value of `minWidth` in `initials-images` so that the previous behaviour is maintained
 
 ## [0.24.0] - 2022-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Remove default value of `minWidth` in `initials-images` so that the previous behaviour is maintained
+* Remove default value of `minWidth` in `initials-images` so that the previous behaviour is maintained - [ripe-white/#1005](https://github.com/ripe-tech/ripe-white/issues/1005)
 
 ## [0.24.0] - 2022-03-14
 

--- a/vue/components/forms/personalization-form/initials-images.vue
+++ b/vue/components/forms/personalization-form/initials-images.vue
@@ -152,7 +152,7 @@ export const InitialsImages = {
          */
         minWidth: {
             type: Number,
-            default: 600
+            default: undefined
         },
         /**
          * If enabled sets a minimum height for each image.


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/1005<br>![image](https://user-images.githubusercontent.com/25725586/159258667-ae49c23c-cc2a-4f57-ae4e-2ec2ef1e88d8.png) |
| Dependencies | -- |
| Decisions | - Remove default value of `minWidth` for `initials-images`, in order to maintain the previous behaviour in initials-images used in personalization modal, which had a hardcoded height of `600px` and not set width. |
| Animated GIF | Now:<br>![image](https://user-images.githubusercontent.com/25725586/159258647-20bd75a9-d13d-47e4-ac81-75635ef24423.png)|
