### PR TITLE
#996: Support for showing videos in White - thumbnails and configurator changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Support for thumbnails that represent a video - [ripe-white/#996](https://github.com/ripe-tech/ripe-white/issues/996)
+* Support for changing frames through thumbnails that point to a video instead of configurator frame - [ripe-white/#996](https://github.com/ripe-tech/ripe-white/issues/996)
 
 ### Changed
 

--- a/vue/components/atoms/thumbnail/thumbnail.vue
+++ b/vue/components/atoms/thumbnail/thumbnail.vue
@@ -110,12 +110,9 @@ export const Thumbnail = {
             this.$bus.trigger("show_frame", this.frame);
         },
         setVideo() {
-            if (!this.frame.startsWith("video")) return;
-
-            const videoThumbnailURL = this.$ripe._getVideoThumbnailURL({
+            this.$refs.image.src = this.$ripe._getVideoThumbnailURL({
                 name: this.frame.split("video-")[1]
             });
-            this.$refs.image.src = videoThumbnailURL;
         },
         onLoaded() {
             this.loaded = true;
@@ -126,7 +123,12 @@ export const Thumbnail = {
         }
     },
     mounted: function() {
-        this.$bus.bind("parts", () => this.setVideo());
+        // binds to the parts event so that if there's a configuration
+        // change then the video image is properly updated
+        this.$bus.bind("parts", () => {
+            if (!this.frame.startsWith("video-")) return;
+            this.setVideo();
+        });
 
         // if the frame is for a video, retrieves the video thumbnail
         // url and sets it as the image's 'src'
@@ -134,6 +136,7 @@ export const Thumbnail = {
             this.setVideo();
             return;
         }
+
         this.image = this.$ripe.bindImage(this.$refs.image, {
             frame: this.frame,
             size: this.size || undefined,

--- a/vue/components/atoms/thumbnail/thumbnail.vue
+++ b/vue/components/atoms/thumbnail/thumbnail.vue
@@ -1,7 +1,7 @@
 <template>
     <img
         class="thumbnail"
-        v-bind:class="{ active: active, loaded: loaded, hide: hide }"
+        v-bind:class="classes"
         v-bind:alt="name"
         src=""
         ref="image"
@@ -95,6 +95,14 @@ export const Thumbnail = {
     computed: {
         active() {
             return this.frame === this.$store.state.currentFrame;
+        },
+        classes() {
+            const base = {
+                active: this.active,
+                loaded: this.loaded,
+                hide: this.hide
+            };
+            return base;
         }
     },
     methods: {
@@ -122,7 +130,7 @@ export const Thumbnail = {
 
         // if the frame is for a video, retrieves the video thumbnail
         // url and sets it as the image's 'src'
-        if (this.frame.startsWith("video")) {
+        if (this.frame.startsWith("video-")) {
             this.setVideo();
             return;
         }

--- a/vue/components/atoms/thumbnail/thumbnail.vue
+++ b/vue/components/atoms/thumbnail/thumbnail.vue
@@ -31,7 +31,7 @@
     opacity: 0.7;
 }
 
-.thumbnail.hide {
+.thumbnail.hidden {
     display: none;
 }
 
@@ -89,7 +89,7 @@ export const Thumbnail = {
         return {
             image: null,
             loaded: false,
-            hide: false
+            hidden: false
         };
     },
     computed: {
@@ -100,7 +100,7 @@ export const Thumbnail = {
             const base = {
                 active: this.active,
                 loaded: this.loaded,
-                hide: this.hide
+                hidden: this.hidden
             };
             return base;
         }
@@ -119,10 +119,10 @@ export const Thumbnail = {
         },
         onLoaded() {
             this.loaded = true;
-            this.hide = false;
+            this.hidden = false;
         },
         onError() {
-            this.hide = true;
+            this.hidden = true;
         }
     },
     mounted: function() {

--- a/vue/components/atoms/thumbnail/thumbnail.vue
+++ b/vue/components/atoms/thumbnail/thumbnail.vue
@@ -100,6 +100,15 @@ export const Thumbnail = {
         }
     },
     mounted: function() {
+        // if the frame is for a video, retrieves the video thumbnail
+        // url and sets it as the image's 'src'
+        if (this.frame.startsWith("video")) {
+            const videoThumbnailURL = this.$ripe._getVideoThumbnailURL({
+                name: this.frame.split("video-")[1]
+            });
+            this.$refs.image.src = videoThumbnailURL;
+            return;
+        }
         this.image = this.$ripe.bindImage(this.$refs.image, {
             frame: this.frame,
             size: this.size || undefined,

--- a/vue/components/atoms/thumbnail/thumbnail.vue
+++ b/vue/components/atoms/thumbnail/thumbnail.vue
@@ -107,20 +107,12 @@ export const Thumbnail = {
         // build the required provider for the frame, if the thumbnail corresponds to a video
         // the URL provider, frame validator and frame differs, as well as the 'doubleBuffering'
         // usage, since the video for certain customizations might not exist
-        const imageUrlProvider = this.frame.startsWith("video-")
-            ? (...args) => this.$ripe._getVideoThumbnailURL(...args)
-            : undefined;
-        const frameValidator = this.frame.startsWith("video-")
-            ? (...args) => this.$ripe.hasVideo(...args)
-            : undefined;
-        const doubleBuffering = !this.frame.startsWith("video-");
-        const frame = this.frame.startsWith("video-") ? this.frame.split("video-")[1] : this.frame;
+        const bindMethod = this.frame.startsWith("video-")
+            ? (...args) => this.$ripe.bindVideoThumbnail(...args)
+            : (...args) => this.$ripe.bindImage(...args);
 
-        this.image = this.$ripe.bindImage(this.$refs.image, {
-            frame: frame,
-            imageUrlProvider: imageUrlProvider,
-            frameValidator: frameValidator,
-            doubleBuffering: doubleBuffering,
+        this.image = bindMethod(this.$refs.image, {
+            frame: this.frame.startsWith("video-") ? this.frame.split("video-")[1] : this.frame,
             size: this.size || undefined,
             crop: this.crop || undefined
         });
@@ -134,11 +126,6 @@ export const Thumbnail = {
     methods: {
         showFrame() {
             this.$bus.trigger("show_frame", this.frame);
-        },
-        setVideo() {
-            this.$refs.image.src = this.$ripe._getVideoThumbnailURL({
-                name: this.frame.split("video-")[1]
-            });
         },
         onLoaded() {
             this.loaded = true;

--- a/vue/components/molecules/thumbnails/thumbnails.vue
+++ b/vue/components/molecules/thumbnails/thumbnails.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="thumbnails" ref="thumbnailsContainer">
         <thumbnail
-            v-bind:frame="`${thumbnail.face}-${thumbnail.frame}`"
+            v-bind:frame="thumbnailFrame(thumbnail)"
             v-bind:name="thumbnail.name"
             v-bind:size="size"
             v-bind:crop="crop"
@@ -31,16 +31,25 @@ export const Thumbnails = {
             // is not part of the base frames definition of the model
             return this.$store.getters.thumbnails.filter(
                 t =>
-                    this.$store.state.config.faces &&
-                    this.$store.state.config.faces_m &&
-                    this.$store.state.config.faces.includes(t.face) &&
-                    this.$store.state.config.faces_m[t.face] &&
-                    t.frame < this.$store.state.config.faces_m[t.face].frames
+                    (this.$store.state.config.faces &&
+                        this.$store.state.config.faces_m &&
+                        this.$store.state.config.faces.includes(t.face) &&
+                        this.$store.state.config.faces_m[t.face] &&
+                        t.frame < this.$store.state.config.faces_m[t.face].frames) ||
+                    (this.$store.state.config.videos &&
+                        this.$store.state.config.videos_m &&
+                        this.$store.state.config.videos.includes(t.name) &&
+                        this.$store.state.config.videos_m[t.name])
             );
         }
     },
     methods: {
+        thumbnailFrame(thumbnail) {
+            if (thumbnail.type === "video") return `video-${thumbnail.name}`;
+            return `${thumbnail.face}-${thumbnail.frame}`;
+        },
         thumbnailKey(thumbnail) {
+            if (thumbnail.type === "video") return `video:${thumbnail.name}`;
             return `${thumbnail.frame}:${thumbnail.name}:${thumbnail.face}`;
         }
     }

--- a/vue/components/organisms/configurator/configurator.vue
+++ b/vue/components/organisms/configurator/configurator.vue
@@ -402,6 +402,8 @@ export const Configurator = {
             this.frameData = value;
         },
         async frameData(value, previous) {
+            if (value.startsWith("video-")) return;
+
             // in case the configurator is not currently ready
             // then avoids the operation (returns control flow)
             if (!this.configurator || !this.configurator.ready) return;

--- a/vue/components/organisms/configurator/configurator.vue
+++ b/vue/components/organisms/configurator/configurator.vue
@@ -402,6 +402,9 @@ export const Configurator = {
             this.frameData = value;
         },
         async frameData(value, previous) {
+            // in case the frame for which a update was requested is
+            // associated with a video, then there's nothing to be done
+            // returns the control flow immediately
             if (value.startsWith("video-")) return;
 
             // in case the configurator is not currently ready


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/996 |
| Dependencies | https://github.com/ripe-tech/ripe-sdk/pull/377 |
| Decisions | - Show thumbnails that map to a video - the standard used was that frames that point to videohave the name `video-<video name>`.<br>- The video and thumbnails update when the customization change, since there might be no video for certain customizations.  |
| Animated GIF | Below |

https://user-images.githubusercontent.com/25725586/159502592-c9097962-8f4b-4efd-9388-129398494e2a.mp4

https://user-images.githubusercontent.com/25725586/159502626-bcfff4e5-2d40-4fac-91a9-e8970cf8ccfc.mp4

