### PR TITLE
version: 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+### Fixed
+
+*
+
+## [0.28.0] - 2022-05-24
+
+### Added
+
 * Added version to all plugins starting at 0.1.0 - [ripe-white/#1026](https://github.com/ripe-tech/ripe-white/issues/1026)
 * Added html support for ´alert´ component  - [ripe-white/#1037](https://github.com/ripe-tech/ripe-white/issues/1037)
 * Support thumbnails for frames that are for personalization only (contain `group` in the thumbnails spec) - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-commons-pluginus",
-    "version": "0.27.0",
+    "version": "0.28.0",
     "description": "RIPE Commons Pluginus",
     "keywords": [
         "commons",


### PR DESCRIPTION
### Added

* Added version to all plugins starting at 0.1.0 - [ripe-white/#1026](https://github.com/ripe-tech/ripe-white/issues/1026)
* Added html support for ´alert´ component  - [ripe-white/#1037](https://github.com/ripe-tech/ripe-white/issues/1037)
* Support thumbnails for frames that are for personalization only (contain `group` in the thumbnails spec) - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)

### Changed

* Support for `showInitials` in `initials-images` as prop - [ripe-white/#978](https://github.com/ripe-tech/ripe-white/issues/978)

### Fixed

* Load bundle locales for size and scale at every `pre_locale_set` event
* Fix storybook dependency problem after minor bump, lock versions to minor - [ripe-welcome/PR#187](https://github.com/ripe-tech/ripe-welcome/pull/187)
* Port `eslint-config-hive` dependencies to solve failing build