### PR TITLE
fix: alert content not showing text data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Fix not showing alert content data text
 
 ## [0.29.0] - 2022-06-08
 

--- a/vue/components/atoms/alert/alert.vue
+++ b/vue/components/atoms/alert/alert.vue
@@ -2,9 +2,7 @@
     <transition name="fade">
         <div class="alert" v-bind:style="style" v-show="isVisible" v-on:click="onClick">
             <global-events v-on:keydown.esc="handleGlobal" />
-            <div class="alert-content" v-html="htmlData">
-                {{ textData }}
-            </div>
+            <div class="alert-content" v-html="alertContent" />
         </div>
     </transition>
 </template>
@@ -77,6 +75,9 @@ export const Alert = {
             const base = {};
             if (this.topOffset !== null) base.top = `${this.topOffset}px`;
             return base;
+        },
+        alertContent() {
+            return this.htmlData || this.textData;
         }
     },
     data: function() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Alert text is not showing when clicking "Copy frame link" button of `link-technical` plugin. <br> Reproducible in [white now](https://ripe-white-now.platforme.com/?brand=swear&model=vyner). Found by @NFSS10   |
| Decisions | - Fix alert content by picking html or text. The previous implementation would always pick html, even if it was `undefined`. |
| Animated GIF | Below |

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/24736423/197518887-80f8754d-c488-4cdd-a700-0a5594f51770.png) | ![image](https://user-images.githubusercontent.com/24736423/197518941-3704e674-9624-4594-be6d-1c6c6a4e95df.png) |