### PR TITLE
#1078 Display restricted options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add `show_restrictions` feature - [ripe-white/#1078](https://github.com/ripe-tech/ripe-white/issues/1078)
 
 ### Changed
 

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -137,14 +137,16 @@
                             v-bind:data-color="colorOption.color"
                             v-bind:class="{
                                 active: isSelected(colorOption),
+                                disabled: isDisabled(activePart, activeMaterial, colorOption.color),
                                 optional: isOptional(activePart),
-                                'no-option': colorOption.color.startsWith('no_')
+                                'no-option': colorOption.color.startsWith('no_'),
+                                unavailable: isUnavailable(activePart, activeMaterial, colorOption.color)
                             }"
                             v-for="colorOption in colorOptions"
                             v-bind:key="colorOption.material + ':' + colorOption.color"
                             v-on:click="() => onColorClick(colorOption)"
                         >
-                            <div class="swatch" v-bind:class="filteredOptions[activePart][activeMaterial][colorOption.color]">
+                            <div class="swatch">
                                 <img
                                     v-bind:src="
                                         colorSwatch(colorOption.material, colorOption.color)
@@ -307,9 +309,11 @@
     z-index: 1;
 }
 
-.pickers .colors-container .color > .swatch.unavailable {
+.pickers .colors-container .color.disabled > .swatch,
+.pickers .colors-container .color.unavailable > .swatch {
     border: 2px solid grey !important;
     padding: 2px;
+    pointer-events:none;
 }
 
 .pickers.multiple-materials .colors-container .color > .swatch {
@@ -341,20 +345,21 @@
     border-radius: 50%;
 }
 
-.pickers .colors-container .color > .swatch.unavailable::after {
+.pickers .colors-container .color.disabled > .swatch::before {
+    content: "";
+    background: linear-gradient(45deg, rgba(0,0,0,0) calc(50% - 2px), rgba(128, 128, 128, 0.8) calc(50%), rgba(0,0,0,0) calc(50% + 2px) );
+    width: 100%;
+    height: 100%;
+    position: absolute;
+}
+
+.pickers .colors-container .color.disabled > .swatch::after,
+.pickers .colors-container .color.unavailable > .swatch::after {
     content: "";
     background: linear-gradient(-45deg, rgba(0,0,0,0) calc(50% - 2px), rgba(128, 128, 128, 0.8) calc(50%), rgba(0,0,0,0) calc(50% + 2px) );
     width: 100%;
     height: 100%;
     margin-left: -100%;
-    position: absolute;
-}
-
-.pickers .colors-container .color > .swatch.unavailable::before {
-    content: "";
-    background: linear-gradient(45deg, rgba(0,0,0,0) calc(50% - 2px), rgba(128, 128, 128, 0.8) calc(50%), rgba(0,0,0,0) calc(50% + 2px) );
-    width: 100%;
-    height: 100%;
     position: absolute;
 }
 
@@ -1026,6 +1031,12 @@ export const Pickers = {
                 (this.currentColor.material === colorOption.material &&
                     this.currentColor.color === colorOption.color)
             );
+        },
+        isDisabled(part, material, color) {
+            return this.showRestrictions && this.restrictionsDisabled && this.filteredOptions[part][material][color];
+        },
+        isUnavailable(part, material, color) {
+            return this.showRestrictions && this.filteredOptions[part][material][color];
         },
         updateSwatches() {
             const swatches = {};

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -314,13 +314,13 @@
     opacity: 50%;
 }
 
-.pickers .colors-container .color.disabled > .swatch {
-    border: 2px solid rgba(128, 128, 128, 0.8) !important;
+.pickers .colors-wrapper .colors-container .color.disabled > .swatch {
+    border: 2px solid rgba(128, 128, 128, 0.8);
     padding: 2px;
 }
 
-.pickers .colors-container .color.unavailable > .swatch {
-    border: 2px solid #ff0000 !important;
+.pickers .colors-wrapper .colors-container .color.unavailable > .swatch {
+    border: 2px solid #ff0000;
     padding: 2px;
 }
 

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -144,7 +144,7 @@
                             v-bind:key="colorOption.material + ':' + colorOption.color"
                             v-on:click="() => onColorClick(colorOption)"
                         >
-                            <div class="swatch">
+                            <div class="swatch" v-bind:class="filteredOptions[activePart][activeMaterial][colorOption.color]">
                                 <img
                                     v-bind:src="
                                         colorSwatch(colorOption.material, colorOption.color)
@@ -307,6 +307,11 @@
     z-index: 1;
 }
 
+.pickers .colors-container .color > .swatch.unavailable {
+    border: 2px solid grey !important;
+    padding: 2px;
+}
+
 .pickers.multiple-materials .colors-container .color > .swatch {
     margin-top: 0px;
 }
@@ -344,6 +349,13 @@
     margin-left: -100%;
     position: absolute;
 }
+
+.pickers .colors-container .color > .swatch.unavailable::before {
+    content: "";
+    background: linear-gradient(45deg, rgba(0,0,0,0) calc(50% - 2px), rgba(128, 128, 128, 0.8) calc(50%), rgba(0,0,0,0) calc(50% + 2px) );
+    width: 100%;
+    height: 100%;
+    position: absolute;
 }
 
 .pickers .colors-container .color > .swatch > .border {

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -554,7 +554,7 @@ export const Pickers = {
             return this.$store.getters.getParts();
         },
         showRestrictions() {
-            return this.$store.state.features?.show_restrictions;
+            return this.$store.state?.features?.["show-restrictions"];
         },
         restrictionsDisabled() {
             return this.$store.state?.extraParameters?.restrictions === "disabled";

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -140,7 +140,11 @@
                                 disabled: isDisabled(activePart, activeMaterial, colorOption.color),
                                 optional: isOptional(activePart),
                                 'no-option': colorOption.color.startsWith('no_'),
-                                unavailable: isUnavailable(activePart, activeMaterial, colorOption.color)
+                                unavailable: isUnavailable(
+                                    activePart,
+                                    activeMaterial,
+                                    colorOption.color
+                                )
                             }"
                             v-for="colorOption in colorOptions"
                             v-bind:key="colorOption.material + ':' + colorOption.color"
@@ -310,15 +314,17 @@
 }
 
 .pickers .colors-container .color.disabled {
+    opacity: 0.5;
     pointer-events: none;
-    opacity: 50%;
 }
 
+.pickers .colors-wrapper .colors-container .color.disabled:hover > .swatch,
 .pickers .colors-wrapper .colors-container .color.disabled > .swatch {
     border: 2px solid rgba(128, 128, 128, 0.8);
     padding: 2px;
 }
 
+.pickers .colors-wrapper .colors-container .color.unavailable:hover > .swatch,
 .pickers .colors-wrapper .colors-container .color.unavailable > .swatch {
     border: 2px solid #ff0000;
     padding: 2px;
@@ -347,28 +353,38 @@
 }
 
 .pickers .colors-container .color > .swatch > img {
+    border-radius: 50%;
     height: 100%;
     object-fit: cover;
     width: 100%;
-    border-radius: 50%;
 }
 
 .pickers .colors-container .color.disabled > .swatch::after {
+    background: linear-gradient(
+        -45deg,
+        rgba(0, 0, 0, 0) calc(50% - 2px),
+        rgba(128, 128, 128, 0.8) calc(50%),
+        rgba(0, 0, 0, 0) calc(50% + 2px)
+    );
     content: "";
-    background: linear-gradient(-45deg, rgba(0,0,0,0) calc(50% - 2px), rgba(128, 128, 128, 0.8) calc(50%), rgba(0,0,0,0) calc(50% + 2px) );
-    width: 100%;
     height: 100%;
     margin-left: -100%;
     position: absolute;
+    width: 100%;
 }
 
 .pickers .colors-container .color.unavailable > .swatch::after {
+    background: linear-gradient(
+        -45deg,
+        rgba(0, 0, 0, 0) calc(50% - 2px),
+        #ff0000 calc(50%),
+        rgba(0, 0, 0, 0) calc(50% + 2px)
+    );
     content: "";
-    background: linear-gradient(-45deg, rgba(0,0,0,0) calc(50% - 2px), #ff0000 calc(50%), rgba(0,0,0,0) calc(50% + 2px) );
-    width: 100%;
     height: 100%;
     margin-left: -100%;
     position: absolute;
+    width: 100%;
 }
 
 .pickers .colors-container .color > .swatch > .border {
@@ -556,7 +572,11 @@ export const Pickers = {
                 for (const [material, materialValue] of Object.entries(partValue.materials)) {
                     const colors = {};
                     for (const [color, colorValue] of Object.entries(materialValue.colors)) {
-                        const unavailable = !(partValue.available && materialValue.available && colorValue.available);
+                        const unavailable = !(
+                            partValue.available &&
+                            materialValue.available &&
+                            colorValue.available
+                        );
                         colors[color] = !this.showRestrictions || unavailable;
                     }
                     if (Object.keys(colors).length === 0) continue;
@@ -1034,10 +1054,18 @@ export const Pickers = {
             );
         },
         isDisabled(part, material, color) {
-            return this.showRestrictions && this.restrictionsDisabled && this.filteredOptions[part][material][color];
+            return (
+                this.showRestrictions &&
+                this.restrictionsDisabled &&
+                this.filteredOptions[part][material][color]
+            );
         },
         isUnavailable(part, material, color) {
-            return this.showRestrictions && !this.restrictionsDisabled && this.filteredOptions[part][material][color];
+            return (
+                this.showRestrictions &&
+                !this.restrictionsDisabled &&
+                this.filteredOptions[part][material][color]
+            );
         },
         updateSwatches() {
             const swatches = {};

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -320,7 +320,7 @@
 
 .pickers .colors-wrapper .colors-container .color.disabled:hover > .swatch,
 .pickers .colors-wrapper .colors-container .color.disabled > .swatch {
-    border: 2px solid rgba(128, 128, 128, 0.8);
+    border: 2px solid #808080cc;
     padding: 2px;
 }
 
@@ -362,9 +362,9 @@
 .pickers .colors-container .color.disabled > .swatch::after {
     background: linear-gradient(
         -45deg,
-        rgba(0, 0, 0, 0) calc(50% - 2px),
-        rgba(128, 128, 128, 0.8) calc(50%),
-        rgba(0, 0, 0, 0) calc(50% + 2px)
+        #00000000 calc(50% - 2px),
+        #808080cc calc(50%),
+        #00000000 calc(50% + 2px)
     );
     content: "";
     height: 100%;
@@ -376,9 +376,9 @@
 .pickers .colors-container .color.unavailable > .swatch::after {
     background: linear-gradient(
         -45deg,
-        rgba(0, 0, 0, 0) calc(50% - 2px),
+        #00000000 calc(50% - 2px),
         #ff0000 calc(50%),
-        rgba(0, 0, 0, 0) calc(50% + 2px)
+        #00000000 calc(50% + 2px)
     );
     content: "";
     height: 100%;
@@ -412,14 +412,14 @@
 
 .button-scroll-right {
     background: url("~./assets/arrow-right.svg") right center no-repeat,
-        linear-gradient(to left, #fafafa, rgba(255, 255, 255, 0));
+        linear-gradient(to left, #fafafa, #ffffff00);
     right: 0px;
     top: 0px;
 }
 
 .button-scroll-left {
     background: url("~./assets/arrow-left.svg") left center no-repeat,
-        linear-gradient(to right, #fafafa, rgba(255, 255, 255, 0));
+        linear-gradient(to right, #fafafa, #ffffff00);
 }
 
 .button-scroll-parts {
@@ -432,11 +432,11 @@
 }
 
 .button-scroll-right.button-scroll-materials {
-    background: linear-gradient(to left, #fafafa, rgba(255, 255, 255, 0)) right center no-repeat;
+    background: linear-gradient(to left, #fafafa, #ffffff00) right center no-repeat;
 }
 
 .button-scroll-left.button-scroll-materials {
-    background: linear-gradient(to right, #fafafa, rgba(255, 255, 255, 0)) left center no-repeat;
+    background: linear-gradient(to right, #fafafa, #ffffff00) left center no-repeat;
 }
 
 body.mobile .button-scroll-materials {

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -333,6 +333,17 @@
     height: 100%;
     object-fit: cover;
     width: 100%;
+    border-radius: 50%;
+}
+
+.pickers .colors-container .color > .swatch.unavailable::after {
+    content: "";
+    background: linear-gradient(-45deg, rgba(0,0,0,0) calc(50% - 2px), rgba(128, 128, 128, 0.8) calc(50%), rgba(0,0,0,0) calc(50% + 2px) );
+    width: 100%;
+    height: 100%;
+    margin-left: -100%;
+    position: absolute;
+}
 }
 
 .pickers .colors-container .color > .swatch > .border {
@@ -501,6 +512,9 @@ export const Pickers = {
         parts() {
             return this.$store.getters.getParts();
         },
+        showRestrictions() {
+            return this.$store.state.features?.show_restrictions;
+        },
         options() {
             return this.$store.state.options;
         },
@@ -510,14 +524,19 @@ export const Pickers = {
         filteredOptions() {
             const choices = {};
             for (const [part, partValue] of Object.entries(this.choices)) {
-                if (!partValue.available) continue;
                 const materials = {};
                 for (const [material, materialValue] of Object.entries(partValue.materials)) {
-                    if (!materialValue.available) continue;
-                    const colors = [];
+                    const colors = {};
                     for (const [color, colorValue] of Object.entries(materialValue.colors)) {
-                        if (!colorValue.available) continue;
-                        colors.push(color);
+                        if (!this.showRestrictions) {
+                            colors[color] = {};
+                        }
+                        else {
+                            const unavailable = !(partValue.available && materialValue.available && colorValue.available);
+                            colors[color] = {
+                                unavailable: unavailable
+                            };
+                        }
                     }
                     if (Object.keys(colors).length === 0) continue;
                     materials[material] = colors;
@@ -1037,7 +1056,7 @@ export const Pickers = {
             for (const material in partColors) {
                 const materialColors = partColors[material];
                 let index = 0;
-                for (const color of materialColors) {
+                for (const color of Object.keys(materialColors)) {
                     colors.push({
                         material: material,
                         color: color,
@@ -1059,7 +1078,7 @@ export const Pickers = {
             const colors = [];
             let index = 0;
             const materialColors = this.materialOptions[material] || [];
-            for (const color of materialColors) {
+            for (const color of Object.keys(materialColors)) {
                 colors.push({
                     material: material,
                     color: color,

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -527,6 +527,9 @@ export const Pickers = {
         showRestrictions() {
             return this.$store.state.features?.show_restrictions;
         },
+        restrictionsDisabled() {
+            return this.$store.state?.extraParameters?.restrictions === "disabled";
+        },
         options() {
             return this.$store.state.options;
         },

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -548,15 +548,8 @@ export const Pickers = {
                 for (const [material, materialValue] of Object.entries(partValue.materials)) {
                     const colors = {};
                     for (const [color, colorValue] of Object.entries(materialValue.colors)) {
-                        if (!this.showRestrictions) {
-                            colors[color] = {};
-                        }
-                        else {
-                            const unavailable = !(partValue.available && materialValue.available && colorValue.available);
-                            colors[color] = {
-                                unavailable: unavailable
-                            };
-                        }
+                        const unavailable = !(partValue.available && materialValue.available && colorValue.available);
+                        colors[color] = !this.showRestrictions || unavailable;
                     }
                     if (Object.keys(colors).length === 0) continue;
                     materials[material] = colors;

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -309,11 +309,19 @@
     z-index: 1;
 }
 
-.pickers .colors-container .color.disabled > .swatch,
-.pickers .colors-container .color.unavailable > .swatch {
-    border: 2px solid grey !important;
+.pickers .colors-container .color.disabled {
+    pointer-events: none;
+    opacity: 50%;
+}
+
+.pickers .colors-container .color.disabled > .swatch {
+    border: 2px solid rgba(128, 128, 128, 0.8) !important;
     padding: 2px;
-    pointer-events:none;
+}
+
+.pickers .colors-container .color.unavailable > .swatch {
+    border: 2px solid #ff0000 !important;
+    padding: 2px;
 }
 
 .pickers.multiple-materials .colors-container .color > .swatch {
@@ -345,18 +353,18 @@
     border-radius: 50%;
 }
 
-.pickers .colors-container .color.disabled > .swatch::before {
+.pickers .colors-container .color.disabled > .swatch::after {
     content: "";
-    background: linear-gradient(45deg, rgba(0,0,0,0) calc(50% - 2px), rgba(128, 128, 128, 0.8) calc(50%), rgba(0,0,0,0) calc(50% + 2px) );
+    background: linear-gradient(-45deg, rgba(0,0,0,0) calc(50% - 2px), rgba(128, 128, 128, 0.8) calc(50%), rgba(0,0,0,0) calc(50% + 2px) );
     width: 100%;
     height: 100%;
+    margin-left: -100%;
     position: absolute;
 }
 
-.pickers .colors-container .color.disabled > .swatch::after,
 .pickers .colors-container .color.unavailable > .swatch::after {
     content: "";
-    background: linear-gradient(-45deg, rgba(0,0,0,0) calc(50% - 2px), rgba(128, 128, 128, 0.8) calc(50%), rgba(0,0,0,0) calc(50% + 2px) );
+    background: linear-gradient(-45deg, rgba(0,0,0,0) calc(50% - 2px), #ff0000 calc(50%), rgba(0,0,0,0) calc(50% + 2px) );
     width: 100%;
     height: 100%;
     margin-left: -100%;
@@ -1029,7 +1037,7 @@ export const Pickers = {
             return this.showRestrictions && this.restrictionsDisabled && this.filteredOptions[part][material][color];
         },
         isUnavailable(part, material, color) {
-            return this.showRestrictions && this.filteredOptions[part][material][color];
+            return this.showRestrictions && !this.restrictionsDisabled && this.filteredOptions[part][material][color];
         },
         updateSwatches() {
             const swatches = {};

--- a/vue/components/organisms/pickers/pickers.vue
+++ b/vue/components/organisms/pickers/pickers.vue
@@ -568,8 +568,10 @@ export const Pickers = {
         filteredOptions() {
             const choices = {};
             for (const [part, partValue] of Object.entries(this.choices)) {
+                if (!partValue.available && !this.showRestrictions) continue;
                 const materials = {};
                 for (const [material, materialValue] of Object.entries(partValue.materials)) {
+                    if (!materialValue.available && !this.showRestrictions) continue;
                     const colors = {};
                     for (const [color, colorValue] of Object.entries(materialValue.colors)) {
                         const unavailable = !(


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/1078 |
| Decisions | * Add feature `show_restrictions` that will allow all restricted colors to still be displayed and clickable by default.<br>* Addicionally an `extraParameters=restrictions:disabled` can be received to change the behaviour to also display the restricted colors but not allow clicking. <br>* Previous behavior (not displaying restrited options) will remain unchanged when no feature is sent.|
| Animated GIFs |Unavailable (still clickable) ![](https://user-images.githubusercontent.com/10127604/200898393-896c4258-e6d8-4150-81c1-4e516c1f55ea.gif) Disabled (not clickable) ![](https://user-images.githubusercontent.com/10127604/200898391-5db8e9d2-7f92-4fb8-b533-58e99b108f7f.gif) |
