### PR TITLE
#1013 Enhace `show_frame` with options and modify `thumbnail` component `onClick` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Change `onClick` event of `thumbnail` component to not trigger `show_frame` and delegate it, instead, to ripe-white's model-viewer - [ripe-white/#1013](https://github.com/ripe-tech/ripe-white/issues/1013)
+* Enhace `show_frame` event bind to also receive `options` as an argument  - [ripe-white/#1013](https://github.com/ripe-tech/ripe-white/issues/1013)
 
 ### Fixed
 

--- a/vue/components/atoms/thumbnail/thumbnail.vue
+++ b/vue/components/atoms/thumbnail/thumbnail.vue
@@ -131,7 +131,7 @@ export const Thumbnail = {
         this.image = null;
     },
     methods: {
-        showViewer() {
+        showViewerFrame() {
             if (this.isVideoFrame(this.frame)) {
                 this.$bus.trigger("show_video", this.frame);
             } else if (this.isPersonalizationFrame(this.frame)) {
@@ -139,9 +139,6 @@ export const Thumbnail = {
             } else {
                 this.$bus.trigger("show_configurator", this.frame);
             }
-        },
-        showFrame() {
-            this.$bus.trigger("show_frame", this.frame);
         },
         initialsGroup(frame) {
             return this.isPersonalizationFrame(frame) ? this.getGroupPersonalization(frame) : null;
@@ -155,10 +152,7 @@ export const Thumbnail = {
                 : null;
         },
         onClick() {
-            this.showViewer();
-
-            if (this.isVideoFrame(this.frame) || this.isPersonalizationFrame(this.frame)) return;
-            this.showFrame();
+            this.showViewerFrame();
         },
         onLoaded() {
             this.loaded = true;

--- a/vue/components/organisms/configurator/configurator.vue
+++ b/vue/components/organisms/configurator/configurator.vue
@@ -375,9 +375,31 @@ export const Configurator = {
             }
         });
 
-        this.$bus.bind("show_frame", async frame => {
+        this.$bus.bind("show_frame", async (frame, options) => {
+            // in case the global bus should be ignore nothing is
+            // done as a consequence of a changed frame
             if (this.ignoreBus) return;
-            this.frameData = frame;
+
+            // avoid infinite loop, by checking if the frame
+            // is the one we're currently on
+            if (this.frameData === frame) return;
+
+            // in case the configurator is not currently ready
+            // then avoids the operation (returns control flow)
+            if (!this.configurator || !this.configurator.ready) {
+                return;
+            }
+
+            try {
+                // triggers the async change frame operation on
+                // the current configurator
+                await this.configurator.changeFrame(frame, options);
+                this.frameData = frame;
+            } catch (error) {
+                // calls the registered callback handler for the
+                // error (default implementation is a simple re-throw)
+                this.onError(error);
+            }
         });
 
         this.$bus.bind("highlight_part", part => {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-white/issues/1013 |
| Decisions | - Change `onClick` event of `thumbnail` component to not trigger `show_frame` and delegate it, instead, to ripe-white's model-viewer <br> - Enhace `show_frame` event bind to also receive `options` as an argument |

