### PR TITLE
chore: version 0.30.0 :rainbow: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+*
+
+### Changed
+
+*
+
+### Fixed
+
+*
+
+## [0.30.0] - 2022-11-10
+
+### Added
+
 * Add `show_restrictions` feature - [ripe-white/#1078](https://github.com/ripe-tech/ripe-white/issues/1078)
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-commons-pluginus",
-    "version": "0.29.0",
+    "version": "0.30.0",
     "description": "RIPE Commons Pluginus",
     "keywords": [
         "commons",


### PR DESCRIPTION
### Added

* Add `show_restrictions` feature - [ripe-white/#1078](https://github.com/ripe-tech/ripe-white/issues/1078)

### Changed
* Change `onClick` event of `thumbnail` component to not trigger `show_frame` and delegate it, instead, to ripe-white's model-viewer - [ripe-white/#1013](https://github.com/ripe-tech/ripe-white/issues/1013)
* Enhace `show_frame` event bind to also receive `options` as an argument  - [ripe-white/#1013](https://github.com/ripe-tech/ripe-white/issues/1013)
### Fixed
* Fix not showing alert content data text