### PR TITLE
Bump CI/CD node engine versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     name: Deploy
     strategy:
       matrix:
-        node-version: [12]
+        node-version: [14]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,4 +24,3 @@ jobs:
           npm publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
- 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     name: Deploy
     strategy:
       matrix:
-        node-version: [14]
+        node-version: [18]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,3 +24,4 @@ jobs:
           npm publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+ 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        node-version: [14, 15, 16, 17, 18, 19]
+        node-version: [14, 16, 18]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        node-version: [12, 13, 14]
+        node-version: [14, 15, 16, 17, 18, 19]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-dist: trusty
-language: node_js
-node_js:
-  - "16"
-  - "17"
-  - "18"
-install:
-  - npm install
-script: npm run lint && npm run build && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: trusty
 language: node_js
 node_js:
   - "16"
-  - "18"
 install:
   - npm install
 script: npm run lint && npm run build && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: trusty
 language: node_js
 node_js:
   - "16"
-  - "17"
   - "18"
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 dist: trusty
 language: node_js
 node_js:
-  - "12"
-  - "13"
-  - "14"
+  - "16"
+  - "17"
+  - "18"
 install:
   - npm install
 script: npm run lint && npm run build && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+dist: trusty
+language: node_js
+node_js:
+  - "16"
+  - "17"
+  - "18"
+install:
+  - npm install
+script: npm run lint && npm run build && npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Bump CI/CD node engine versions to LTS from 14 to 18
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Bump CI/CD node engine versions from 14 to 18 LTS
+* Remove Travis CI/CD workflow
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Bump CI/CD node engine versions from 14 to 18 LTS
-* Remove Travis CI/CD workflow
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Bump CI/CD node engine versions to LTS from 14 to 18
+* Bump CI/CD node engine versions from 14 to 18 LTS
 
 ### Fixed
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Builds are now failing because postcss [no loger supports node 12](https://github.com/postcss/postcss/blob/main/package.json#L6). Yarn actually informs of this and prevents the install but npm installer continues but later fails the build. Also, considering the current node LTS 18, we should consider updating versions. |
| Decisions | - Update node engine version of our github workflows  |
