### PR TITLE
version 0.31.1 :rainbow: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Bump CI/CD node engine versions from 14 to 18 LTS
-* Improve CSR deinitialization process to allow CSR model swapping - [ripe-sdk/#493](https://github.com/ripe-tech/ripe-sdk/issues/493)
+*
 
 ### Fixed
 
 *
 
+## [0.31.1] - 2023-03-14
+
+### Changed
+
+* Bump CI/CD node engine versions from 14 to 18 LTS
+* Improve CSR deinitialization process to allow CSR model swapping - [ripe-sdk/#493](https://github.com/ripe-tech/ripe-sdk/issues/493)
 ## [0.31.0] - 2023-02-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-commons-pluginus",
-    "version": "0.31.0",
+    "version": "0.31.1",
     "description": "RIPE Commons Pluginus",
     "keywords": [
         "commons",


### PR DESCRIPTION
### Changed

* Bump CI/CD node engine versions from 14 to 18 LTS
* Improve CSR deinitialization process to allow CSR model swapping - [ripe-sdk/#493](https://github.com/ripe-tech/ripe-sdk/issues/493)