### PR TITLE
#493 Update `ripe-sdk` to version `3.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Update ripe-sdk to `3.0.0` - [ripe-sdk/#493](https://github.com/ripe-tech/ripe-sdk/issues/491)
+* Update ripe-sdk to `3.0.0` - [ripe-sdk/#491](https://github.com/ripe-tech/ripe-sdk/issues/491)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Update ripe-sdk to `3.0.0` - [ripe-sdk/#493](https://github.com/ripe-tech/ripe-sdk/issues/491)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dependencies": {
         "loaders.css": "^0.1.2",
         "pluginus": "^0.4.2",
-        "ripe-sdk": "^2.40.0",
+        "ripe-sdk": "^3.0.0",
         "vue": "^2.6.14",
         "vue-global-events": "^1.2.1",
         "vuex": "^3.6.2",


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk/issues/491 |
| Dependencies | -- |
| Decisions | Update `ripe-sdk` version to `3.0.0` |
